### PR TITLE
server personality + user_data support

### DIFF
--- a/jumpgate/compute/drivers/sl/servers.py
+++ b/jumpgate/compute/drivers/sl/servers.py
@@ -183,7 +183,11 @@ class ServersV2(object):
 
         user_data = {}
         if lookup(body, 'server', 'metadata'):
-            user_data = lookup(body, 'server', 'metadata')
+            user_data['metadata'] = lookup(body, 'server', 'metadata')
+        if lookup(body, 'server', 'user_data'):
+            user_data['user_data'] = lookup(body, 'server', 'user_data')
+        if lookup(body, 'server', 'personality'):
+            user_data['personality'] = lookup(body, 'server', 'personality')
 
         datacenter = None
         if lookup(body, 'server', 'availability_zone'):


### PR DESCRIPTION
adds basic support for server 'personalities' and 'user_data' as per [jumpgate issue 32](https://github.com/softlayer/jumpgate/issues/32) and [jumpgate issue 31](https://github.com/softlayer/jumpgate/issues/31)

The content is passed through as JSON structured data as discussed in the jumpgate issues mentioned above.

For example:

```
curl https://api.service.softlayer.com/rest/v3/SoftLayer_Resource_Metadata/UserMetadata.txt
{"user_data": "W0RFRkFVTFRdCmd1ZXN0X2lkPTEKdGVuYW50X2lkPIIsd77", "metadata": {"key2": "val2", "key1": "val1"}}
```
