### PR TITLE
admin_token identity support

### DIFF
--- a/etc/jumpgate.conf
+++ b/etc/jumpgate.conf
@@ -1,6 +1,7 @@
 [DEFAULT]
 enabled_services = identity, compute, image, block_storage, network, baremetal
 log_level = INFO
+admin_token = ADMIN
 secret_key = SET ME TO SOMETHING
 
 [softlayer]

--- a/jumpgate/common/sl/__init__.py
+++ b/jumpgate/common/sl/__init__.py
@@ -27,7 +27,8 @@ def hook_get_client(req, resp, kwargs):
         if 'X-AUTH-TOKEN' in req.headers:
             admin_token = cfg.CONF['DEFAULT']['admin_token']
             if admin_token and admin_token == req.headers.get('X-AUTH-TOKEN'):
-                # authn for jumpgate api, but no mapping into slapi
+                # admin_token authenticates to Jumpgate API, but does not
+                # provide SLAPI access
                 return
             tenant_id = kwargs.get('tenant_id',
                                    req.headers.get('X-AUTH-PROJECT-ID'))


### PR DESCRIPTION
adds basic admin_token support to jumpgate whereupon a shared secret
(the admin_token) can be used to authn/z to the jumpgate API. this
secret does not map into the SLAPI.

implements https://github.com/softlayer/jumpgate/issues/35
