### PR TITLE
return server.id as string

### DIFF
--- a/jumpgate/compute/drivers/sl/servers.py
+++ b/jumpgate/compute/drivers/sl/servers.py
@@ -415,7 +415,7 @@ def get_server_details_dict(app, req, instance):
     image_name = ''
 
     results = {
-        'id': instance['id'],
+        'id': str(instance['id']),
         'accessIPv4': '',
         'accessIPv6': '',
         'addresses': addresses,


### PR DESCRIPTION
returns server.id as a string rather then number.
fixes https://github.com/softlayer/jumpgate/issues/37
