### PR TITLE
return user_id in server details

### DIFF
--- a/jumpgate/compute/drivers/sl/servers.py
+++ b/jumpgate/compute/drivers/sl/servers.py
@@ -446,6 +446,10 @@ def get_server_details_dict(app, req, instance):
         'security_groups': [{'name': 'default'}],
         'status': status,
         'tenant_id': tenant_id,
+        # NOTE(bodenr): userRecordId accessibility determined by permissions
+        # of API caller's user id and api key. Otherwise it will be None
+        'user_id': lookup(instance, 'billingItem', 'orderItem', 'order',
+                          'userRecordId'),
         'updated': instance['modifyDate'],
         'image_name': image_name,
     }
@@ -487,6 +491,7 @@ def get_virtual_guest_mask():
         'modifyDate',
         'provisionDate',
         'sshKeys',
+        'billingItem.orderItem.order.userRecordId'
     ]
 
     return 'mask[%s]' % ','.join(mask)


### PR DESCRIPTION
obtains and returns the cci creator user id in a servers response.
however a cci creator user id is only accessible if the API callers
credentials permit it. in cases where not accessible a JSON value of
null is sent over the wire for the server.user_id

implements https://github.com/softlayer/jumpgate/issues/39
