### PR TITLE
Handling issue #52

### DIFF
--- a/jumpgate/compute/drivers/sl/servers.py
+++ b/jumpgate/compute/drivers/sl/servers.py
@@ -403,12 +403,14 @@ def get_server_details_dict(app, req, instance):
         addresses['private'] = [{
             'addr': instance.get('primaryBackendIpAddress'),
             'version': 4,
+            'OS-EXT-IPS:type': 'fixed',
         }]
 
     if instance.get('primaryIpAddress'):
         addresses['public'] = [{
             'addr': instance.get('primaryIpAddress'),
             'version': 4,
+            'OS-EXT-IPS:type': 'public',
         }]
 
     # TODO - Don't hardcode this

--- a/jumpgate/compute/drivers/sl/servers.py
+++ b/jumpgate/compute/drivers/sl/servers.py
@@ -410,7 +410,7 @@ def get_server_details_dict(app, req, instance):
         addresses['public'] = [{
             'addr': instance.get('primaryIpAddress'),
             'version': 4,
-            'OS-EXT-IPS:type': 'floating',
+            'OS-EXT-IPS:type': 'fixed',
         }]
 
     # TODO - Don't hardcode this

--- a/jumpgate/compute/drivers/sl/servers.py
+++ b/jumpgate/compute/drivers/sl/servers.py
@@ -410,7 +410,7 @@ def get_server_details_dict(app, req, instance):
         addresses['public'] = [{
             'addr': instance.get('primaryIpAddress'),
             'version': 4,
-            'OS-EXT-IPS:type': 'public',
+            'OS-EXT-IPS:type': 'floating',
         }]
 
     # TODO - Don't hardcode this


### PR DESCRIPTION
Many consumers of the compute service uses 'OS-EXT-IPS:type' field,
which is easy to support as SL always assigns private
(primaryBackendIpAddress) and public (primaryIpAddress) IPs which can be
categorized into 'fixed' and 'public' respectively.
