### PR TITLE
identity bug fixes for non-url friendly tokens + get /tokens/{id} authn

### DIFF
--- a/jumpgate/common/hooks/auth_token.py
+++ b/jumpgate/common/hooks/auth_token.py
@@ -10,7 +10,9 @@ LOG = logging.getLogger(__name__)
 NOAUTH = [re.compile(e) for e in ['GET:/$', 'GET:\/v[\d]+[\/]?$',
                                   'GET:\/v[\d]+.[\d]+[\/]?$',
                                   'POST:\/v[\d]+\/tokens$',
-                                  'POST:\/v[\d]+.[\d]+\/tokens$']]
+                                  'POST:\/v[\d]+.[\d]+\/tokens$',
+                                  'GET:\/v[\d]+\/tokens/\w+$',
+                                  'GET:\/v[\d]+.[\d]+\/tokens/\w+$']]
 
 
 def protected(target):

--- a/jumpgate/identity/drivers/core.py
+++ b/jumpgate/identity/drivers/core.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import logging
 import time
@@ -241,10 +242,10 @@ class AESTokenIdDriver(TokenIdDriver):
         super(AESTokenIdDriver, self).__init__()
 
     def create_token_id(self, token):
-        return aes.encode_aes(json.dumps(token))
+        return base64.b64encode(aes.encode_aes(json.dumps(token)))
 
     def token_from_id(self, token_id):
         try:
-            return json.loads(aes.decode_aes(token_id))
+            return json.loads(aes.decode_aes(base64.b64decode(token_id)))
         except (TypeError, ValueError):
             raise exceptions.InvalidTokenError('Malformed token')

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -91,7 +91,8 @@ class TestHookAuthToken(unittest.TestCase):
 
     def test_unprotected(self):
         for api in ['GET:/v2', 'GET:/v2/', 'GET:/v3.0', 'GET:/v3.0/',
-                    'GET:/v10.22', 'POST:/v2/tokens', 'POST:/v2.1/tokens']: 
+                    'GET:/v10.22', 'POST:/v2/tokens', 'POST:/v2.1/tokens',
+                    'GET:/v2/tokens/a8Vs7bS', 'GET:/v2.0/tokens/a8Vs7bS']: 
             req = MagicMock()
             req.headers = {'X-AUTH-TOKEN': None}
             req.method = api.split(':')[0]


### PR DESCRIPTION
implements fixes for the following:
- Tokens can be generated which are non-url friendly. This impacts the
  consumers ability to use the token on a GET /tokens/{token_id} call.
- The API pipeline should allow unauthenticated calls to GET
  /tokens/{token_id} to validate an existing token

fixes https://github.com/softlayer/jumpgate/issues/55
