### PR TITLE
nova CCI metadata / user-data / personality cloud-init mitigation

### DIFF
--- a/tools/bin/cci_init
+++ b/tools/bin/cci_init
@@ -25,59 +25,19 @@ import os
 import urllib2
 
 
-class JSONRESTClient(object):
-    """a simple json rest client
-    """
-    def __init__(self, token=None):
-        self.token = token
-
-    def get(self, url):
-        """perform a http GET on the url
-
-        :param url: the url to GET
-        """
-        return self._rest_call(url)
-
-    def post(self, url, json_body):
-        """perform a http POST on the url
-
-        :param url: the url to POST
-        :param json_body: the body to POST
-        """
-        return self._rest_call(url, 'POST', json_body)
-
-    def put(self, url, json_body):
-        """perform a http PUT on the url
-
-        :param url: the url to PUT
-        :param json_body: the body to PUT
-        """
-        return self._rest_call(url, 'PUT', json_body)
-
-    def delete(self, url):
-        """perform an http DELETE on the url
-
-        :param url: the url to DELETE
-        """
-        return self._rest_call(url, 'DELETE')
-
-    def _rest_call(self, url, method='GET', json_body=None):
-        request = urllib2.Request(url)
-        request.add_header('Content-Type', 'application/json;charset=utf8')
-        request.add_header('Accept', 'application/json')
-        request.add_header('User-Agent', 'python-client')
-        if self.token:
-            request.add_header('X-Auth-Token', self.token)
-        if json_body:
-            request.add_data(json.dumps(json_body))
-        request.get_method = lambda: method
-        try:
-            response = urllib2.urlopen(request)
-        except urllib2.HTTPError as e:
-            if e.code == 300:
-                return json.loads(e.read())
-            raise e
-        return json.loads(response.read())
+def json_get(url):
+    request = urllib2.Request(url)
+    request.add_header('User-Agent', 'python-client')
+    request.add_header('Content-Type', 'application/json;charset=utf8')
+    request.add_header('Accept', 'application/json')
+    request.get_method = lambda: 'GET'
+    try:
+        response = urllib2.urlopen(request)
+    except urllib2.HTTPError as e:
+        if e.code == 300:
+            return json.loads(e.read())
+        raise e
+    return json.loads(response.read())
 
 
 """example response of cci user and metadata
@@ -95,20 +55,22 @@ example response of cci personality
 
 _cci_data = None
 
+
 def rm(path):
     try:
         os.remove(path)
     except OSError:
         pass
 
+
 def get_cci_data():
     global _cci_data
     if _cci_data is not None:
         return _cci_data
-    client = JSONRESTClient()
-    _cci_data = client.get("https://api.service.softlayer.com/rest/v3/"
-                      "SoftLayer_Resource_Metadata/UserMetadata.txt")
+    _cci_data = json_get("https://api.service.softlayer.com/rest/v3/"
+                         "SoftLayer_Resource_Metadata/UserMetadata.txt")
     return _cci_data
+
 
 def get_cci_personality():
     personality = get_cci_data().get('personality', [])
@@ -116,8 +78,10 @@ def get_cci_personality():
         mapping['contents'] = base64.b64decode(mapping['contents'])
     return personality
 
+
 def get_cci_metadata():
     return get_cci_data().get('metadata', None)
+
 
 def get_cci_userdata():
     userdata = get_cci_data().get('user_data', None)
@@ -125,27 +89,30 @@ def get_cci_userdata():
         return base64.b64decode(userdata)
     return None
 
+
 def process_personalities():
     for personality in get_cci_personality():
         rm(personality['path'])
-        with open(personality['path'], 'w') as file:
-            file.write(personality['contents'])
+        with open(personality['path'], 'w') as f:
+            f.write(personality['contents'])
+
 
 def process_userdata():
     data = get_cci_userdata()
     if data is None:
         return
     rm('/etc/user_data')
-    with open('/etc/user_data', 'w') as file:
-        file.write()
+    with open('/etc/user_data', 'w') as f:
+        f.write()
+
 
 def process_metadata():
     data = get_cci_metadata()
     if data is None:
         return
     rm('/etc/metadata')
-    with open('/etc/metadata', 'w') as file:
-        file.write(data)
+    with open('/etc/metadata', 'w') as f:
+        f.write(data)
 
 
 if __name__ == '__main__':

--- a/tools/bin/cci_init
+++ b/tools/bin/cci_init
@@ -103,7 +103,7 @@ def process_userdata():
         return
     rm('/etc/user_data')
     with open('/etc/user_data', 'w') as f:
-        f.write()
+        f.write(str(data))
 
 
 def process_metadata():
@@ -112,7 +112,7 @@ def process_metadata():
         return
     rm('/etc/metadata')
     with open('/etc/metadata', 'w') as f:
-        f.write(data)
+        f.write(json.dumps(data))
 
 
 if __name__ == '__main__':

--- a/tools/bin/cci_init
+++ b/tools/bin/cci_init
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+"""
+This script pulls down SoftLayer CCI user-data and processes it
+as follows:
+
+:personality: realized as the path and contents in the personality
+    userdata.
+:user_data: realized in /etc/user_data
+:metadata: realized in /etc/metadata
+
+For guest activation, make this script executable and put into:
+    /etc/network/if-up.d/
+This will cause the script to be run automatically when networking
+support comes up.
+
+This script does not provide the full active capabilities you would
+find with a config-drive Cloud-Init implementation. Rather it's intent
+is to provide support for raw data realization as a stop-gap mitigation
+until such support is added for SoftLayer CCI metadata.
+"""
+
+import base64
+import json
+import os
+import urllib2
+
+
+class JSONRESTClient(object):
+    """a simple json rest client
+    """
+    def __init__(self, token=None):
+        self.token = token
+
+    def get(self, url):
+        """perform a http GET on the url
+
+        :param url: the url to GET
+        """
+        return self._rest_call(url)
+
+    def post(self, url, json_body):
+        """perform a http POST on the url
+
+        :param url: the url to POST
+        :param json_body: the body to POST
+        """
+        return self._rest_call(url, 'POST', json_body)
+
+    def put(self, url, json_body):
+        """perform a http PUT on the url
+
+        :param url: the url to PUT
+        :param json_body: the body to PUT
+        """
+        return self._rest_call(url, 'PUT', json_body)
+
+    def delete(self, url):
+        """perform an http DELETE on the url
+
+        :param url: the url to DELETE
+        """
+        return self._rest_call(url, 'DELETE')
+
+    def _rest_call(self, url, method='GET', json_body=None):
+        request = urllib2.Request(url)
+        request.add_header('Content-Type', 'application/json;charset=utf8')
+        request.add_header('Accept', 'application/json')
+        request.add_header('User-Agent', 'python-client')
+        if self.token:
+            request.add_header('X-Auth-Token', self.token)
+        if json_body:
+            request.add_data(json.dumps(json_body))
+        request.get_method = lambda: method
+        try:
+            response = urllib2.urlopen(request)
+        except urllib2.HTTPError as e:
+            if e.code == 300:
+                return json.loads(e.read())
+            raise e
+        return json.loads(response.read())
+
+
+"""example response of cci user and metadata
+
+{"user_data": "W0RFRkFVTFRdCmd1ZXN0X2lkPTEKdGVuYW50X2lkPIIsd77",
+    "metadata": {"key2": "val2", "key1": "val1"}}
+
+example response of cci personality
+
+    {"personality": [{"path": "/etc/guest_info", "contents":
+        "W0RFRkFVTFRdCmd1ZXN0X2lkPTA4MmNjOWZkLTIyMjctNDA3My04NTU4
+        LWE2OTJlNmI5ZWFlNQpk\nYXRhc3RvcmVfbWFuYWdlcj1teXNxbAp0ZW
+        5hbnRfaWQ9Mjc4MTg0Cg==\n"}]}
+"""
+
+_cci_data = None
+
+def rm(path):
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
+def get_cci_data():
+    global _cci_data
+    if _cci_data is not None:
+        return _cci_data
+    client = JSONRESTClient()
+    _cci_data = client.get("https://api.service.softlayer.com/rest/v3/"
+                      "SoftLayer_Resource_Metadata/UserMetadata.txt")
+    return _cci_data
+
+def get_cci_personality():
+    personality = get_cci_data().get('personality', [])
+    for mapping in personality:
+        mapping['contents'] = base64.b64decode(mapping['contents'])
+    return personality
+
+def get_cci_metadata():
+    return get_cci_data().get('metadata', None)
+
+def get_cci_userdata():
+    userdata = get_cci_data().get('user_data', None)
+    if userdata is not None:
+        return base64.b64decode(userdata)
+    return None
+
+def process_personalities():
+    for personality in get_cci_personality():
+        rm(personality['path'])
+        with open(personality['path'], 'w') as file:
+            file.write(personality['contents'])
+
+def process_userdata():
+    data = get_cci_userdata()
+    if data is None:
+        return
+    rm('/etc/user_data')
+    with open('/etc/user_data', 'w') as file:
+        file.write()
+
+def process_metadata():
+    data = get_cci_metadata()
+    if data is None:
+        return
+    rm('/etc/metadata')
+    with open('/etc/metadata', 'w') as file:
+        file.write(data)
+
+
+if __name__ == '__main__':
+    process_personalities()
+    process_userdata()
+    process_metadata()


### PR DESCRIPTION
As I'm sure you guys know, OpenStack nova compute supports the ability
to pass through the following data on a boot VM call:
- User Data http://docs.openstack.org/user-guide/content/user-data.html
- Arbitrary key/value pairs as metadata
  http://docs.openstack.org/grizzly/openstack-compute/admin/content/instance-data.html
- Server personality
  http://docs.openstack.org/api/openstack-compute/2/content/Server_Personality-d1e2543.html

In an OpenStack proper environment such "metadata" is typically realized
using something like Cloud-Init + Config Drive
(http://cloudinit.readthedocs.org/en/latest/topics/datasources.html#config-drive).

In SoftLayer we obviously have the CCI user metadata service to pass
arbitrary data through and make it accessible to a CCI. However, to the
best of my knowledge there is no support integrating Cloud-Init +
SoftLayer CCI user metadata. This leaves us with a gap in the SoftLayer
/ nova compute space -- how to realize nova metadata customization on a
CCI via Jumpgate.

To me an ideal solution would be to implement a datasource
(http://cloudinit.readthedocs.org/en/latest/topics/datasources.html)
provider for Cloud-Init which is compatible with SoftLayer's CCI user
metadata. However such an implementation is likely a bit of work.

As a mitigation I have implemented a simple 'cci_init' python script
which can realize all 3 flavors of nova metadata in it's simplest form
-- it realizes raw metadata but does not support any "active
capabilities" of Cloud-Init. Thus I feel it provides a stopgap for
some of the metadata functionality in the nova / Jumpgate space.
