### PR TITLE
Addresses #6: Swift location import supported

### DIFF
--- a/jumpgate/image/__init__.py
+++ b/jumpgate/image/__init__.py
@@ -2,6 +2,10 @@
 def add_endpoints(disp):
     # V2 API - http://api.openstack.org/api-ref-image.html#os-images-2.0
 
+    disp.add_endpoint('v2_schema_members',
+                      '/v2/schemas/members')
+    disp.add_endpoint('v2_schema_member',
+                      '/v2/schemas/member')
     disp.add_endpoint('v2_schema_image',
                       '/v2/schemas/image')
     disp.add_endpoint('v2_schema_images',

--- a/jumpgate/image/drivers/sl/__init__.py
+++ b/jumpgate/image/drivers/sl/__init__.py
@@ -1,4 +1,5 @@
-from .images import ImageV1, ImagesV1, SchemaImageV2, SchemaImagesV2, ImagesV2
+from .images import ImageV1, ImagesV1, SchemaImageV2, \
+    SchemaImagesV2, ImagesV2, SchemaMemberV2, SchemaMembersV2
 from jumpgate.common.sl import add_hooks
 
 
@@ -8,6 +9,8 @@ def setup_routes(app, disp):
     disp.set_handler('v2_images', ImagesV2(app))
     disp.set_handler('v2_images_detail', ImagesV2(app))
     disp.set_handler('v2_schema_image', SchemaImageV2())
+    disp.set_handler('v2_schema_member', SchemaMemberV2())
+    disp.set_handler('v2_schema_members', SchemaMembersV2())
     disp.set_handler('v2_schema_images', SchemaImagesV2())
 
     # V1 Routes


### PR DESCRIPTION
When Swift direct-url with account name, container and object name is
given that is used to import image template using
SoftLayer_Virtual_Guest_Block_Device_Template_Group service.
