### PR TITLE
Adds .json suffix to each route

### DIFF
--- a/jumpgate/api.py
+++ b/jumpgate/api.py
@@ -68,6 +68,7 @@ class Jumpgate(object):
             for endpoint, handler in disp.get_routes():
                 LOG.debug("Loading endpoint %s", endpoint)
                 api.add_route(endpoint, handler)
+                api.add_route('%s.json' % endpoint, handler)
 
         return api
 

--- a/jumpgate/network/__init__.py
+++ b/jumpgate/network/__init__.py
@@ -3,6 +3,6 @@
 def add_endpoints(disp):
     # V2 API - http://api.openstack.org/api-ref-networking.html
 
-    disp.add_endpoint('v2_networks', '/v2.0/networks.json')
-    disp.add_endpoint('v2_subnets', '/v2.0/subnets.json')
+    disp.add_endpoint('v2_networks', '/v2.0/networks')
+    disp.add_endpoint('v2_subnets', '/v2.0/subnets')
     disp.add_endpoint('v2_subnet', '/v2.0/subnets/{subnet_id}')

--- a/tests/test_jumpgate.py
+++ b/tests/test_jumpgate.py
@@ -2,11 +2,8 @@ import unittest
 from mock import MagicMock, call, patch
 
 from jumpgate.api import Jumpgate
-from jumpgate.common.hooks import APIHooks
 from jumpgate.common.hooks.core import hook_format, hook_set_uuid
-from jumpgate.common.hooks.log import log_request
 from jumpgate.common.dispatcher import Dispatcher
-from jumpgate.common.nyi import NYI
 
 import falcon
 
@@ -55,7 +52,7 @@ class TestJumpgate(unittest.TestCase):
         api = self.app.make_api()
         self.assertTrue(hasattr(api, '__call__'))
         self.assertIsInstance(api, falcon.API)
-        self.assertEqual(len(api._routes), 10)
+        self.assertEqual(len(api._routes), 20)
 
     def test_add_get_dispatcher(self):
         disp = Dispatcher()


### PR DESCRIPTION
This fixes an issue where clients were expecting most (all?) routes to be able to have a .json suffix.
