### PR TITLE
Retrieved associated endpoints with given token

### DIFF
--- a/jumpgate/identity/drivers/sl/__init__.py
+++ b/jumpgate/identity/drivers/sl/__init__.py
@@ -23,5 +23,5 @@ def setup_routes(app, disp):
         raise ValueError('Template file not found')
 
     disp.set_handler('v2_tokens', TokensV2(template_file))
-
+    disp.set_handler('v2_token_endpoints', TokensV2(template_file))
     add_hooks(app)

--- a/jumpgate/identity/drivers/sl/tokens.py
+++ b/jumpgate/identity/drivers/sl/tokens.py
@@ -176,6 +176,28 @@ class TokensV2(object):
         resp.status = 200
         resp.body = {'access': access}
 
+    def on_get(self, req, resp, token_id):
+        tokens = identity.token_driver()
+        token = identity.token_id_driver().token_from_id(token_id)
+        identity.token_driver().validate_token(token)
+        raw_endpoints = self._get_catalog(tokens.tenant_id(token),
+                                          tokens.user_id(token))
+        endpoints = []
+        for services in raw_endpoints.values():
+            for service_type, service in services.items():
+                d = {
+                    'adminURL': service.get('adminURL'),
+                    'name': service.get('name', 'Unknown'),
+                    'publicURL': service.get('publicURL'),
+                    'privateURL': service.get('privateURL'),
+                    'region': service.get('region', 'RegionOne'),
+                    'tenantId': tokens.tenant_id(token),
+                    'type': service_type,
+                }
+                endpoints.append(d)
+        resp.status = 200
+        resp.body = {'endpoints': endpoints, 'endpoints_links': []}
+
 
 class TokenV2(object):
     def on_get(self, req, resp, token_id):


### PR DESCRIPTION
Handling Identity endpoint-list using specified token #58
According to Identity API Specification [1], endpoints should be returned with following request:
GET v2.0/tokens/{tokenId}/endpoints
[1]http://api.openstack.org/api-ref-identity.html#identity-v2
