### PR TITLE
support for default domain in jumpgate.conf

### DIFF
--- a/etc/jumpgate.conf
+++ b/etc/jumpgate.conf
@@ -5,6 +5,7 @@ admin_token = ADMIN
 secret_key = SET ME TO SOMETHING
 request_hooks = jumpgate.common.hooks.admin_token, jumpgate.common.hooks.auth_token, jumpgate.common.hooks.sl.client
 response_hooks = jumpgate.common.hooks.log
+default_domain = jumpgate.com
 
 [softlayer]
 endpoint = https://api.softlayer.com/xmlrpc/v3/

--- a/jumpgate/common/config.py
+++ b/jumpgate/common/config.py
@@ -16,7 +16,8 @@ FILE_OPTIONS = {
                    default='SET ME',
                    help='Secret key used to encrypt tokens'),
         cfg.ListOpt('request_hooks', default=[]),
-        cfg.ListOpt('response_hooks', default=[])
+        cfg.ListOpt('response_hooks', default=[]),
+        cfg.StrOpt('default_domain', default='jumpgate.com')
     ],
     'softlayer': [
         cfg.StrOpt('endpoint', default=API_PUBLIC_ENDPOINT),

--- a/jumpgate/compute/drivers/sl/servers.py
+++ b/jumpgate/compute/drivers/sl/servers.py
@@ -2,6 +2,7 @@ import json
 
 from SoftLayer import CCIManager, SshKeyManager, SoftLayerAPIError
 
+from jumpgate.common.config import CONF
 from jumpgate.common.utils import lookup
 from jumpgate.common.error_handling import (bad_request, duplicate,
                                             compute_fault, not_found)
@@ -197,7 +198,7 @@ class ServersV2(object):
 
         payload = {
             'hostname': body['server']['name'],
-            'domain': 'jumpgate.com',  # TODO - Don't hardcode this
+            'domain': CONF['default_domain'] or 'jumpgate.com',
             'cpus': flavor['cpus'],
             'memory': flavor['ram'],
             'hourly': True,  # TODO - How do we set this accurately?


### PR DESCRIPTION
adds support for the specification of the default domain to use when
booting servers in the conf file rather than hardcoding it to
'jumpgate.com' in the py code. this is a partial implementation of
https://github.com/softlayer/jumpgate/issues/63 which allows
configurable domain per jumpgate service. a future PR will include
additional support such as that discussed in
https://github.com/softlayer/jumpgate/issues/63
