### PR TITLE
A temp fix proxy option

### DIFF
--- a/jumpgate/common/hooks/sl/client.py
+++ b/jumpgate/common/hooks/sl/client.py
@@ -1,4 +1,4 @@
-from SoftLayer import Client
+import SoftLayer
 from oslo.config import cfg
 from jumpgate.common.hooks import request_hook
 from jumpgate.common.sl.auth import get_auth
@@ -6,8 +6,12 @@ from jumpgate.common.sl.auth import get_auth
 
 @request_hook(True)
 def bind_client(req, resp, kwargs):
-    client = Client(endpoint_url=cfg.CONF['softlayer']['endpoint'],
-                    proxy=cfg.CONF['softlayer']['proxy'])
+    extra_args = {}
+    if SoftLayer.__version__ > 'v3.0.3':
+        extra_args['proxy'] = cfg.CONF['softlayer']['proxy']
+
+    client = SoftLayer.Client(endpoint_url=cfg.CONF['softlayer']['endpoint'],
+                              **extra_args)
     client.auth = None
     req.env['sl_client'] = client
 


### PR DESCRIPTION
This is a temp fix for softlayer-python < 3.1.0 which doesn't have the ability to specify a proxy when standing up a new client. Addresses #67
