### PR TITLE
Instances with a TEAR_DOWN transaction state will cause the task_state to be 'deleting'

### DIFF
--- a/jumpgate/compute/drivers/sl/servers.py
+++ b/jumpgate/compute/drivers/sl/servers.py
@@ -369,7 +369,8 @@ def get_server_details_dict(app, req, instance):
     transaction = lookup(
         instance, 'activeTransaction', 'transactionStatus', 'name')
 
-    if transaction and 'RECLAIM' in transaction:
+    if transaction and any(['RECLAIM' in transaction,
+                            'TEAR_DOWN' in transaction]):
         task_state = 'deleting'
     else:
         task_state = transaction


### PR DESCRIPTION
This fixes one instance where #46 happens
