### PR TITLE
Jumpgate server command

### DIFF
--- a/jumpgate/cmd.py
+++ b/jumpgate/cmd.py
@@ -1,0 +1,31 @@
+import os
+import argparse
+from wsgiref.simple_server import make_server
+
+from jumpgate.wsgi import make_api
+
+
+def main():
+    description = 'Start a single-threaded instance of jumpgate.'
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument('--config',
+                        default=os.environ.get('JUMPGATE_CONFIG'),
+                        help='Jumpgate config location')
+    parser.add_argument('--host',
+                        default='127.0.0.1',
+                        help='host to listen on')
+    parser.add_argument('--port',
+                        type=int,
+                        default=5000,
+                        help='port to listen on')
+
+    args = parser.parse_args()
+    httpd = make_server(args.host, args.port, make_api(args.config))
+    print("Starting server on (%s:%s)" % (args.host, args.port))
+    print("Warning: This is currently a test server for Jumpgate and not fit"
+          "for production since it is single-threaded. Use the WSGI"
+          "application directly: jumpgate.wsgi:make_api()")
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("Exiting...")

--- a/jumpgate/cmd.py
+++ b/jumpgate/cmd.py
@@ -22,9 +22,11 @@ def main():
     args = parser.parse_args()
     httpd = make_server(args.host, args.port, make_api(args.config))
     print("Starting server on (%s:%s)" % (args.host, args.port))
-    print("Warning: This is currently a test server for Jumpgate and not fit"
-          "for production since it is single-threaded. Use the WSGI"
-          "application directly: jumpgate.wsgi:make_api()")
+    print("""
+Warning: This is currently a test server for Jumpgate and not fit for
+production since it is single-threaded. Use the WSGI application directly
+along with a better wsgi server like gunicorn or uwsgi:
+    jumpgate.wsgi:make_api()""")
     try:
         httpd.serve_forever()
     except KeyboardInterrupt:

--- a/jumpgate/wsgi.py
+++ b/jumpgate/wsgi.py
@@ -1,22 +1,35 @@
 import os.path
 import os
 import logging
+from oslo.config import cfg
 
 from jumpgate.api import Jumpgate
 from jumpgate.config import CONF
 
+PROJECT = 'jumpgate'
 
-def make_api():
-    config_files = None
+
+def make_api(config=None):
+    # Find configuration files
+    config_files = cfg.find_config_files(PROJECT)
+
+    # Check for environmental variable config file
     env_config_loc = os.environ.get('JUMPGATE_CONFIG')
     if env_config_loc and os.path.exists(env_config_loc):
-        config_files = [env_config_loc]
+        config_files.insert(0, env_config_loc)
 
-    CONF(project='jumpgate',
+    # Check for explit config file
+    if config and os.path.exists(config):
+        config_files.insert(0, config)
+
+    if not config_files:
+        raise Exception('No config files for %s found.' % PROJECT)
+
+    CONF(project=PROJECT,
          args=[],  # We don't want CLI arguments to pass through here
          default_config_files=config_files)
 
-    logger = logging.getLogger('jumpgate')
+    logger = logging.getLogger(PROJECT)
     logger.setLevel(getattr(logging, CONF['log_level'].upper()))
     logger.addHandler(logging.StreamHandler())
     app = Jumpgate()

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,9 @@ setup(
         'softlayer',
         'pycrypto',
         'iso8601',
+        'gunicorn>=17.0',
     ],
     setup_requires=[],
     test_suite='nose.collector',
+    entry_points={'console_scripts': ['jumpgate = jumpgate.cmd:main']}
 )

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
         'softlayer',
         'pycrypto',
         'iso8601',
-        'gunicorn>=17.0',
     ],
     setup_requires=[],
     test_suite='nose.collector',

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -5,3 +5,4 @@ oslo.config>=1.2.0
 softlayer
 pycrypto
 iso8601
+gunicorn>=17.0

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -5,4 +5,3 @@ oslo.config>=1.2.0
 softlayer
 pycrypto
 iso8601
-gunicorn>=17.0


### PR DESCRIPTION
The server uses wsgiref so it's single threaded and not suited for production use.

Example usage:

``` bash
$ jumpgate --config=etc/jumpgate.conf
```
