### PR TITLE
return network.id as a string

### DIFF
--- a/jumpgate/network/__init__.py
+++ b/jumpgate/network/__init__.py
@@ -6,3 +6,4 @@ def add_endpoints(disp):
     disp.add_endpoint('v2_networks', '/v2.0/networks')
     disp.add_endpoint('v2_subnets', '/v2.0/subnets')
     disp.add_endpoint('v2_subnet', '/v2.0/subnets/{subnet_id}')
+    disp.add_endpoint('v2_extensions', '/v2.0/extensions')

--- a/jumpgate/network/drivers/sl/__init__.py
+++ b/jumpgate/network/drivers/sl/__init__.py
@@ -1,5 +1,6 @@
 from .subnets import SubnetsV2
 from .networks import NetworksV2
+from .extensions import ExtensionsV2
 from jumpgate.common.sl import add_hooks
 
 
@@ -7,5 +8,6 @@ def setup_routes(app, disp):
     # V2 Routes
     disp.set_handler('v2_networks', NetworksV2())
     disp.set_handler('v2_subnets', SubnetsV2())
+    disp.set_handler('v2_extensions', ExtensionsV2())
 
     add_hooks(app)

--- a/jumpgate/network/drivers/sl/extensions.py
+++ b/jumpgate/network/drivers/sl/extensions.py
@@ -1,0 +1,6 @@
+
+
+class ExtensionsV2(object):
+    def on_get(self, req, resp):
+        # client = req.env['sl_client']
+        resp.body = {'extensions': []}

--- a/jumpgate/network/drivers/sl/networks.py
+++ b/jumpgate/network/drivers/sl/networks.py
@@ -13,5 +13,5 @@ def format_network(vlan):
         'subnets': [str(subnet['id']) for subnet in vlan['subnets']],
         'admin_state_up': True,
         'name': vlan.get('name'),
-        'id': vlan['id'],
+        'id': str(vlan['id']),
     }


### PR DESCRIPTION
return network.id as a string rather than number
fix #91
