### PR TITLE
Identity-V3 with token and services/user support

### DIFF
--- a/etc/identity_v3.templates
+++ b/etc/identity_v3.templates
@@ -1,0 +1,30 @@
+
+catalog.RegionOne.identity.name = Identity Service
+catalog.RegionOne.identity.publicURL = http://localhost:5000/v3
+catalog.RegionOne.identity.privateURL = http://localhost:5000/v3
+catalog.RegionOne.identity.adminURL = http://localhost:5000/v3
+
+catalog.RegionOne.baremetal.name = Bare Metal Service
+catalog.RegionOne.baremetal.publicURL = http://localhost:5000/v2/baremetal
+catalog.RegionOne.baremetal.privateURL = http://localhost:5000/v2/baremetal
+catalog.RegionOne.baremetal.adminURL = http://localhost:5000/v2/baremetal
+
+catalog.RegionOne.compute.name = Compute Service
+catalog.RegionOne.compute.publicURL = http://localhost:5000/compute/v2/$(tenant_id)s
+catalog.RegionOne.compute.privateURL = http://localhost:5000/compute/v2/$(tenant_id)s
+catalog.RegionOne.compute.adminURL = http://localhost:5000/compute/v2/$(tenant_id)s
+
+catalog.RegionOne.image.name = Image Service
+catalog.RegionOne.image.publicURL = http://localhost:5000/image/v2
+catalog.RegionOne.image.privateURL = http://localhost:5000/image/v2
+catalog.RegionOne.image.adminURL = http://localhost:5000/image/v2
+
+catalog.RegionOne.network.name = Image Service
+catalog.RegionOne.network.publicURL = http://localhost:5000/network/
+catalog.RegionOne.network.privateURL = http://localhost:5000/network/
+catalog.RegionOne.network.adminURL = http://localhost:5000/network/
+
+#catalog.RegionOne.volume.name = Block Storage Service
+#catalog.RegionOne.volume.publicURL = http://localhost:5000/volume/v1/$(tenant_id)s
+#catalog.RegionOne.volume.privateURL = http://localhost:5000/volume/v1/$(tenant_id)s
+#catalog.RegionOne.volume.adminURL = http://localhost:5000/volume/v1/$(tenant_id)s

--- a/etc/jumpgate.conf
+++ b/etc/jumpgate.conf
@@ -10,6 +10,7 @@ default_domain = jumpgate.com
 [softlayer]
 endpoint = https://api.softlayer.com/xmlrpc/v3/
 catalog_template_file = identity.templates
+catalog_template_file_v3 = identity_v3.templates
 
 [openstack]
 compute_endpoint = http://127.0.0.1:8774

--- a/jumpgate/common/sl/__init__.py
+++ b/jumpgate/common/sl/__init__.py
@@ -1,6 +1,40 @@
+from SoftLayer import Client, API_PUBLIC_ENDPOINT
+from oslo.config import cfg
+
+from jumpgate.common.sl.auth import get_auth, get_token_details
 from jumpgate.common.sl.errors import handle_softlayer_errors
 from SoftLayer import SoftLayerAPIError
 
+opts = [
+    cfg.StrOpt('endpoint', default=API_PUBLIC_ENDPOINT),
+    cfg.StrOpt('catalog_template_file', default='identity.templates'),
+    cfg.StrOpt('catalog_template_file_v3', default='identity.templates_v3'),
+]
+
+cfg.CONF.register_opts(opts, group='softlayer')
+
+
+def hook_get_client(req, resp, kwargs):
+    client = Client(endpoint_url=cfg.CONF['softlayer']['endpoint'])
+    client.auth = None
+    req.env['tenant_id'] = None
+
+    if req.headers.get('X-AUTH-TOKEN'):
+        if 'X-AUTH-TOKEN' in req.headers:
+            tenant_id = kwargs.get('tenant_id',
+                                   req.headers.get('X-AUTH-PROJECT-ID'))
+            token_details = get_token_details(req.headers['X-AUTH-TOKEN'],
+                                              tenant_id=tenant_id)
+
+            client.auth = get_auth(token_details)
+
+            req.env['tenant_id'] = token_details['tenant_id']
+
+    req.env['sl_client'] = client
+
 
 def add_hooks(app):
+    if hook_get_client not in app.before_hooks:
+        app.before_hooks.append(hook_get_client)
+
     app.add_error_handler(SoftLayerAPIError, handle_softlayer_errors)

--- a/jumpgate/common/sl/auth.py
+++ b/jumpgate/common/sl/auth.py
@@ -2,7 +2,6 @@ import time
 import json
 import base64
 import logging
-import os
 
 from SoftLayer import (
     Client, SoftLayerAPIError, TokenAuthentication, BasicAuthentication)

--- a/jumpgate/common/sl/auth.py
+++ b/jumpgate/common/sl/auth.py
@@ -1,5 +1,138 @@
-from SoftLayer import (TokenAuthentication, BasicAuthentication)
+import time
+import json
+import base64
+import logging
+import os
 
+from SoftLayer import (
+    Client, SoftLayerAPIError, TokenAuthentication, BasicAuthentication)
+
+from oslo.config import cfg
+from jumpgate.common.aes import decode_aes
+from jumpgate.common.utils import lookup
+from jumpgate.common.exceptions import Unauthorized
+from jumpgate.identity.drivers import core as identity
+
+USER_MASK = 'id, username, accountId'
+LOG = logging.getLogger(__name__)
+
+def get_token_details(token, tenant_id=None):
+    try:
+        token_details = json.loads(decode_aes(base64.b64decode(token)))
+    except (TypeError, ValueError):
+        raise Unauthorized('Invalid Key')
+
+    if time.time() > token_details['expires']:
+        raise Unauthorized('Expired Key')
+
+    if tenant_id and str(token_details['tenant_id']) != tenant_id:
+        raise Unauthorized('Tenant/token Mismatch')
+
+    return token_details
+
+
+def get_new_token(credentials):
+    username = lookup(credentials, 'auth', 'passwordCredentials', 'username')
+    credential = lookup(credentials, 'auth', 'passwordCredentials', 'password')
+
+    def assert_tenant(user):
+        tenant = lookup(credentials, 'auth', 'tenantId')
+        if tenant and str(user['accountId']) != tenant:
+            raise Unauthorized('Invalid username, password or tenant id')
+
+    # If the 'password' is the right length, treat it as an API api_key
+    if len(credential) == 64:
+        client = Client(username=username, api_key=credential)
+        user = client['Account'].getCurrentUser(mask=USER_MASK)
+        assert_tenant(user)
+        return {'username': username,
+                'api_key': credential,
+                'auth_type': 'api_key',
+                'tenant_id': str(user['accountId']),
+                'expires': time.time() + (60 * 60 * 24)}, user
+    else:
+        client = Client()
+        client.auth = None
+        try:
+            userId, tokenHash = client.authenticate_with_password(username,
+                                                                  credential)
+            user = client['Account'].getCurrentUser(mask=USER_MASK)
+            assert_tenant(user)
+            return {'userId': userId,
+                    'tokenHash': tokenHash,
+                    'auth_type': 'token',
+                    'tenant_id': str(user['accountId']),
+                    'expires': time.time() + (60 * 60 * 24)}, user
+        except SoftLayerAPIError as e:
+            if e.faultCode == 'SoftLayer_Exception_User_Customer_LoginFailed':
+                raise Unauthorized(e.faultString)
+            raise
+
+def get_new_token_v3(credentials):
+    token_driver = identity.token_driver()
+    token_id = lookup(credentials, 'auth', 'identity', 'token', 'id')
+    if token_id:
+        LOG.info("token id is: %s", str(token_id))
+        token = identity.token_id_driver().token_from_id(token_id)
+        LOG.info("token details are: %s", str(token))
+
+        token_driver.validate_token(token)
+        username = token_driver.username(token)
+        credential = token_driver.credential(token)
+        userinfo = {'username': username,
+                'auth_type': str(token['auth_type']),
+                'tenant_id': str(token['tenant_id']),
+                'expires': token['expires'] }
+        if token['auth_type'] == 'token':
+            userinfo['tokenHash'] = credential
+        if token['auth_type'] == 'api_key':
+            userinfo['api_key'] = credential
+        user = {'id': token['user_id'],
+                'username': username,
+                'accountId': token['tenant_id']
+               }
+        return userinfo, user
+
+    LOG.info("credentials = " + str(credentials.keys()) + " values = " + str(credentials.values()))
+    username = lookup(credentials, 'auth', 'passwordCredentials', 'username')
+    credential = lookup(credentials, 'auth', 'passwordCredentials', 'password')
+
+   # If the 'password' is the right length, treat it as an API api_key
+    if len(credential) == 64:
+        client = Client(username=username, api_key=credential,
+                        endpoint_url=cfg.CONF['softlayer']['endpoint'],
+                        proxy=cfg.CONF['softlayer']['proxy'])
+        user = client['Account'].getCurrentUser(mask=USER_MASK)
+
+        username = token_driver.username(user)
+
+        return {'username': username,
+                'api_key': credential,
+                'auth_type': 'api_key',
+                'tenant_id': str(user['accountId']),
+                'expires': time.time() + (60 * 60 * 24)}, user
+
+    else:
+        client = Client(endpoint_url=cfg.CONF['softlayer']['endpoint'],
+                            proxy=cfg.CONF['softlayer']['proxy'])
+        client.auth = None
+        try:
+            userId, tokenHash = client.authenticate_with_password(username,
+                                                                  credential)
+            # The tokenHash is a returned hash of user's password from Softlayer to be used
+            user = client['Account'].getCurrentUser(mask=USER_MASK)
+            username = token_driver.username(user)
+            return {'userId': userId,
+                    'username': username,
+                    'tokenHash': tokenHash,
+                    'auth_type': 'token',
+                    'tenant_id': str(user['accountId']),
+                    'expires': time.time() + (60 * 60 * 24)}, user
+
+        except SoftLayerAPIError as e:
+            if e.faultCode == 'SoftLayer_Exception_User_Customer_LoginFailed':
+                raise Unauthorized(e.faultString)
+            raise
 
 def get_auth(token_details):
     if token_details['auth_type'] == 'api_key':

--- a/jumpgate/common/sl/auth.py
+++ b/jumpgate/common/sl/auth.py
@@ -16,6 +16,7 @@ from jumpgate.identity.drivers import core as identity
 USER_MASK = 'id, username, accountId'
 LOG = logging.getLogger(__name__)
 
+
 def get_token_details(token, tenant_id=None):
     try:
         token_details = json.loads(decode_aes(base64.b64decode(token)))
@@ -68,6 +69,7 @@ def get_new_token(credentials):
                 raise Unauthorized(e.faultString)
             raise
 
+
 def get_new_token_v3(credentials):
     token_driver = identity.token_driver()
     token_id = lookup(credentials, 'auth', 'identity', 'token', 'id')
@@ -79,23 +81,22 @@ def get_new_token_v3(credentials):
         username = token_driver.username(token)
         credential = token_driver.credential(token)
         userinfo = {'username': username,
-                'auth_type': str(token['auth_type']),
-                'tenant_id': str(token['tenant_id']),
-                'expires': token['expires'] }
+                    'auth_type': str(token['auth_type']),
+                    'tenant_id': str(token['tenant_id']),
+                    'expires': token['expires']}
         if token['auth_type'] == 'token':
             userinfo['tokenHash'] = credential
         if token['auth_type'] == 'api_key':
             userinfo['api_key'] = credential
         user = {'id': token['user_id'],
                 'username': username,
-                'accountId': token['tenant_id']
-               }
+                'accountId': token['tenant_id']}
         return userinfo, user
 
     username = lookup(credentials, 'auth', 'passwordCredentials', 'username')
     credential = lookup(credentials, 'auth', 'passwordCredentials', 'password')
 
-   # If the 'password' is the right length, treat it as an API api_key
+    # If the 'password' is the right length, treat it as an API api_key
     if len(credential) == 64:
         client = Client(username=username, api_key=credential,
                         endpoint_url=cfg.CONF['softlayer']['endpoint'],
@@ -112,12 +113,11 @@ def get_new_token_v3(credentials):
 
     else:
         client = Client(endpoint_url=cfg.CONF['softlayer']['endpoint'],
-                            proxy=cfg.CONF['softlayer']['proxy'])
+                        proxy=cfg.CONF['softlayer']['proxy'])
         client.auth = None
         try:
             userId, tokenHash = client.authenticate_with_password(username,
                                                                   credential)
-            # The tokenHash is a returned hash of user's password from Softlayer to be used
             user = client['Account'].getCurrentUser(mask=USER_MASK)
             username = token_driver.username(user)
             return {'userId': userId,
@@ -131,6 +131,7 @@ def get_new_token_v3(credentials):
             if e.faultCode == 'SoftLayer_Exception_User_Customer_LoginFailed':
                 raise Unauthorized(e.faultString)
             raise
+
 
 def get_auth(token_details):
     if token_details['auth_type'] == 'api_key':

--- a/jumpgate/common/sl/auth.py
+++ b/jumpgate/common/sl/auth.py
@@ -72,9 +72,8 @@ def get_new_token_v3(credentials):
     token_driver = identity.token_driver()
     token_id = lookup(credentials, 'auth', 'identity', 'token', 'id')
     if token_id:
-        LOG.info("token id is: %s", str(token_id))
         token = identity.token_id_driver().token_from_id(token_id)
-        LOG.info("token details are: %s", str(token))
+        LOG.debug("token details are: %s", str(token))
 
         token_driver.validate_token(token)
         username = token_driver.username(token)
@@ -93,7 +92,6 @@ def get_new_token_v3(credentials):
                }
         return userinfo, user
 
-    LOG.info("credentials = " + str(credentials.keys()) + " values = " + str(credentials.values()))
     username = lookup(credentials, 'auth', 'passwordCredentials', 'username')
     credential = lookup(credentials, 'auth', 'passwordCredentials', 'password')
 

--- a/jumpgate/identity/__init__.py
+++ b/jumpgate/identity/__init__.py
@@ -5,7 +5,10 @@ def add_endpoints(disp):
 
     # V3 API - http://api.openstack.org/api-ref-identity.html#identity-v3
 
+    disp.add_endpoint('v3_auth_index', '/v3')
     # Tokens
+
+    disp.add_endpoint('v3_auth_tokens', '/v3/auth/tokens')
     disp.add_endpoint('v3_tokens', '/v3/tokens')
 
     # Service Catalog

--- a/jumpgate/identity/drivers/sl/__init__.py
+++ b/jumpgate/identity/drivers/sl/__init__.py
@@ -4,18 +4,24 @@ from .user import UserV2
 from .tenants import TenantsV2
 from .tokens import TokensV2, TokenV2
 from .versions import Versions
+from .v3 import V3
+from .servicesV3 import ServicesV3
+from .authTokensV3 import AuthTokensV3
+from .userProjectsV3 import UserProjectsV3
 from jumpgate.common.sl import add_hooks
 
 
 def setup_routes(app, disp):
     # V3 Routes
-    # None currently supported
+    disp.set_handler('v3_auth_index',V3(disp))
+    disp.set_handler('v3_user_projects', UserProjectsV3())
 
     # V2 Routes
     disp.set_handler('v2_tenants', TenantsV2())
     disp.set_handler('v2_token', TokenV2())
-    disp.set_handler('versions', Versions(disp))
     disp.set_handler('v2_user', UserV2())
+
+    disp.set_handler('versions', Versions(disp))
 
     template_file = app.config.softlayer.catalog_template_file
     if not os.path.exists(template_file):
@@ -24,6 +30,20 @@ def setup_routes(app, disp):
     if template_file is None:
         raise ValueError('Template file not found')
 
+    template_file_v3 = app.config.softlayer.catalog_template_file_v3
+    if not os.path.exists(template_file_v3):
+        template_file_v3 = app.config.find_file(template_file_v3)
+
+    if template_file_v3 is None:
+        raise ValueError('Template file v3 not found')
+
     disp.set_handler('v2_tokens', TokensV2(template_file))
     disp.set_handler('v2_token_endpoints', TokensV2(template_file))
+
+    #V3 auth token route
+    disp.set_handler('v3_auth_tokens',AuthTokensV3(template_file_v3))
+
+    #V3 service
+    disp.set_handler('v3_services',ServicesV3(template_file_v3))
+
     add_hooks(app)

--- a/jumpgate/identity/drivers/sl/__init__.py
+++ b/jumpgate/identity/drivers/sl/__init__.py
@@ -13,7 +13,7 @@ from jumpgate.common.sl import add_hooks
 
 def setup_routes(app, disp):
     # V3 Routes
-    disp.set_handler('v3_auth_index',V3(disp))
+    disp.set_handler('v3_auth_index', V3(disp))
     disp.set_handler('v3_user_projects', UserProjectsV3())
 
     # V2 Routes
@@ -40,10 +40,10 @@ def setup_routes(app, disp):
     disp.set_handler('v2_tokens', TokensV2(template_file))
     disp.set_handler('v2_token_endpoints', TokensV2(template_file))
 
-    #V3 auth token route
-    disp.set_handler('v3_auth_tokens',AuthTokensV3(template_file_v3))
+    # V3 auth token route
+    disp.set_handler('v3_auth_tokens', AuthTokensV3(template_file_v3))
 
-    #V3 service
-    disp.set_handler('v3_services',ServicesV3(template_file_v3))
+    # V3 service
+    disp.set_handler('v3_services', ServicesV3(template_file_v3))
 
     add_hooks(app)

--- a/jumpgate/identity/drivers/sl/authTokensV3.py
+++ b/jumpgate/identity/drivers/sl/authTokensV3.py
@@ -3,7 +3,8 @@ import logging
 import json
 import base64
 
-from jumpgate.common.sl.auth import get_new_token_v3, get_token_details, get_auth
+from jumpgate.common.sl.auth import get_auth, get_new_token_v3
+from jumpgate.common.sl.auth import get_token_details
 from jumpgate.common.aes import encode_aes
 
 from SoftLayer import Client
@@ -64,15 +65,14 @@ def get_access_v3(token_id, token_details, user):
         'token': {
             'expires_at': datetime.datetime.fromtimestamp(
                 token_details['expires']).isoformat(),
-             'issued_at': datetime.datetime.fromtimestamp(
+            'issued_at': datetime.datetime.fromtimestamp(
                 token_details['expires']).isoformat(),
-             'methods':['password'],
-             'id':token_id,
-             'user': {
-                 'id': user['id'],
-                 'links': [0],
-                 'name': user['username'],
-             },
+            'methods': ['password'],
+            'id': token_id,
+            'user': {
+                'id': user['id'],
+                'links': [0],
+                'name': user['username']}
         }
     }
 
@@ -106,28 +106,27 @@ class AuthTokensV3(object):
         for services in raw_catalog.values():
             for service_type, service in services.items():
                 d = {
-#                   'id': "????"
+                    # 'id': "????"
                     'type': service_type,
                     'name': service.get('name', 'Unknown'),
                     'endpoints': [{
-#                       'id': "????"
+                        # 'id': "????"
                         'interface': "internal",
                         'region': service.get('region', 'RegionOne'),
                         'url': service.get('privateURL')
-                    },
-                    {
-#                       'id': "????"
+                        },
+                        {
+                        # 'id': "????"
                         'interface': "public",
                         'region': service.get('region', 'RegionOne'),
                         'url': service.get('publicURL')
-                    },
-                    {
-#                       'id': "????"
+                        },
+                        {
+                        # 'id': "????"
                         'interface': "admin",
                         'region': service.get('region', 'RegionOne'),
                         'url': service.get('adminURL'),
-                    }
-                                  ]
+                        }]
                 }
                 catalog.append(d)
         return catalog
@@ -139,13 +138,12 @@ class AuthTokensV3(object):
         token_id = base64.b64encode(encode_aes(json.dumps(token_details)))
 
         access = get_access_v3(token_id, token_details, user)
-
-         # Add catalog to the access data
+        # Add catalog to the access data
         catalog = self._build_catalog(token_details, user)
         access['token']['catalog'] = catalog
 
         resp.status = 200
-        resp.set_header('X-Subject-Token',str(token_id))
+        resp.set_header('X-Subject-Token', str(token_id))
         # V2 APIs return the body in 'access' keypair but V3 APIs do not
         # resp.body = {'access': access}
         resp.body = access

--- a/jumpgate/identity/drivers/sl/authTokensV3.py
+++ b/jumpgate/identity/drivers/sl/authTokensV3.py
@@ -1,0 +1,173 @@
+import datetime
+import logging
+import json
+import base64
+
+from jumpgate.common.sl.auth import get_new_token_v3, get_token_details, get_auth
+from jumpgate.common.aes import encode_aes
+
+from SoftLayer import Client
+from oslo.config import cfg
+
+LOG = logging.getLogger(__name__)
+
+
+def parse_templates(template_lines):
+    o = {}
+    for line in template_lines:
+        if ' = ' not in line:
+            continue
+
+        k, v = line.strip().split(' = ')
+        if not k.startswith('catalog.'):
+            continue
+
+        parts = k.split('.')
+
+        region, service, key = parts[1:4]
+
+        region_ref = o.get(region, {})
+        service_ref = region_ref.get(service, {})
+        service_ref[key] = v
+
+        region_ref[service] = service_ref
+        o[region] = region_ref
+
+    return o
+
+
+def get_access(token_id, token_details, user):
+    return {
+        'token': {
+            'expires': datetime.datetime.fromtimestamp(
+                token_details['expires']).isoformat(),
+            'id': token_id,
+            'tenant': {
+                'id': token_details['tenant_id'],
+                'name': token_details['tenant_id'],
+            },
+        },
+        'user': {
+            'username': user['username'],
+            'id': user['id'],
+            'roles': [
+                {'name': 'user'},
+            ],
+            'role_links': [],
+            'name': user['username'],
+        },
+    }
+
+
+def get_access_v3(token_id, token_details, user):
+    return {
+        'token': {
+            'expires_at': datetime.datetime.fromtimestamp(
+                token_details['expires']).isoformat(),
+             'issued_at': datetime.datetime.fromtimestamp(
+                token_details['expires']).isoformat(),
+             'methods':['password'],
+             'id':token_id,
+             'user': {
+                 'id': user['id'],
+                 'links': [0],
+                 'name': user['username'],
+             },
+        }
+    }
+
+
+class AuthTokensV3(object):
+    def __init__(self, template_file):
+        self._load_templates(template_file)
+
+    def _load_templates(self, template_file):
+        try:
+            self.templates = parse_templates(open(template_file))
+        except IOError:
+            LOG.critical('Unable to open template file %s', template_file)
+            raise
+
+    def _get_catalog(self, tenant_id, user_id):
+        d = {'tenant_id': tenant_id, 'user_id': user_id}
+
+        o = {}
+        for region, region_ref in self.templates.items():
+            o[region] = {}
+            for service, service_ref in region_ref.items():
+                o[region][service] = {}
+                for k, v in service_ref.items():
+                    o[region][service][k] = v.replace('$(', '%(') % d
+        return o
+
+    def _build_catalog(self, token_details, user):
+        raw_catalog = self._get_catalog(token_details['tenant_id'], user['id'])
+        catalog = []
+        for services in raw_catalog.values():
+            for service_type, service in services.items():
+                d = {
+#                   'id': "????"
+                    'type': service_type,
+                    'name': service.get('name', 'Unknown'),
+                    'endpoints': [{
+#                       'id': "????"
+                        'interface': "internal",
+                        'region': service.get('region', 'RegionOne'),
+                        'url': service.get('privateURL')
+                    },
+                    {
+#                       'id': "????"
+                        'interface': "public",
+                        'region': service.get('region', 'RegionOne'),
+                        'url': service.get('publicURL')
+                    },
+                    {
+#                       'id': "????"
+                        'interface': "admin",
+                        'region': service.get('region', 'RegionOne'),
+                        'url': service.get('adminURL'),
+                    }
+                                  ]
+                }
+                catalog.append(d)
+        return catalog
+
+    def on_post(self, req, resp):
+        body = req.stream.read().decode()
+        credentials = json.loads(body)
+        token_details, user = get_new_token_v3(credentials)
+        token_id = base64.b64encode(encode_aes(json.dumps(token_details)))
+
+        access = get_access_v3(token_id, token_details, user)
+
+         # Add catalog to the access data
+        catalog = self._build_catalog(token_details, user)
+        access['token']['catalog'] = catalog
+
+        resp.status = 200
+        resp.set_header('X-Subject-Token',str(token_id))
+        # V2 APIs return the body in 'access' keypair but V3 APIs do not
+        # resp.body = {'access': access}
+        resp.body = access
+
+
+class TokenV2(object):
+    def on_get(self, req, resp, token_id):
+        token_details = get_token_details(token_id,
+                                          tenant_id=req.get_param('belongsTo'))
+        client = Client(endpoint_url=cfg.CONF['softlayer']['endpoint'])
+        client.auth = get_auth(token_details)
+
+        user = client['Account'].getCurrentUser(mask='id, username')
+        access = get_access(token_id, token_details, user)
+
+        resp.status = 200
+        resp.body = {'access': access}
+
+    def on_delete(self, req, resp, token_id):
+        # This method is called when OpenStack wants to remove a token's
+        # validity, such as when a cookie expires. Our login tokens can't
+        # be forced to expire yet, so this does nothing.
+        LOG.warning('User attempted to delete token: %s', token_id)
+        resp.status = 202
+        resp.body = ''

--- a/jumpgate/identity/drivers/sl/servicesV3.py
+++ b/jumpgate/identity/drivers/sl/servicesV3.py
@@ -1,0 +1,93 @@
+import datetime
+import logging
+import json
+import base64
+
+from jumpgate.common.sl.auth import get_new_token, get_token_details, get_auth
+from jumpgate.common.aes import encode_aes
+
+from SoftLayer import Client
+from oslo.config import cfg
+
+LOG = logging.getLogger(__name__)
+
+
+
+
+def parse_templates(template_lines):
+    o = {}
+    for line in template_lines:
+        if ' = ' not in line:
+            continue
+
+        k, v = line.strip().split(' = ')
+        if not k.startswith('catalog.'):
+            continue
+
+        parts = k.split('.')
+
+        region, service, key = parts[1:4]
+
+        region_ref = o.get(region, {})
+        service_ref = region_ref.get(service, {})
+        service_ref[key] = v
+
+        region_ref[service] = service_ref
+        o[region] = region_ref
+
+    return o
+
+class ServicesV3(object):
+    def __init__(self, template_file):
+        self._load_templates(template_file)
+
+    def _load_templates(self, template_file):
+        try:
+            self.templates = parse_templates(open(template_file))
+        except IOError:
+            LOG.critical('Unable to open template file %s', template_file)
+            raise
+
+    def _get_catalog(self, tenant_id, user_id):
+        d = {'tenant_id': tenant_id, 'user_id': user_id}
+
+        o = {}
+        for region, region_ref in self.templates.items():
+            o[region] = {}
+            for service, service_ref in region_ref.items():
+                o[region][service] = {}
+                for k, v in service_ref.items():
+                    o[region][service][k] = v.replace('$(', '%(') % d
+        return o
+    def on_get(self, req, resp):
+        client = req.env['sl_client']
+        account = client['Account'].getObject()
+
+        tenants = [
+            {
+                'enabled': True,
+                'description': None,
+                'name': str(account['id']),
+                'id': str(account['id']),
+            },
+        ]
+
+        # Add catalog to the access data
+        raw_catalog = self._get_catalog(account['id'], account['id'])
+        catalog = []
+        for services in raw_catalog.values():
+            for service_type, service in services.items():
+                d = {
+                    'type': service_type,
+                    'name': service.get('name', 'Unknown'),
+                    'endpoints': [{
+                        'region': service.get('region', 'RegionOne'),
+                        'publicURL': service.get('publicURL'),
+                        'privateURL': service.get('privateURL'),
+                        'adminURL': service.get('adminURL'),
+                    }],
+                    'endpoint_links': [],
+                }
+                catalog.append(d)
+
+        resp.body = catalog

--- a/jumpgate/identity/drivers/sl/servicesV3.py
+++ b/jumpgate/identity/drivers/sl/servicesV3.py
@@ -1,13 +1,4 @@
-import datetime
 import logging
-import json
-import base64
-
-from jumpgate.common.sl.auth import get_new_token, get_token_details, get_auth
-from jumpgate.common.aes import encode_aes
-
-from SoftLayer import Client
-from oslo.config import cfg
 
 LOG = logging.getLogger(__name__)
 
@@ -63,12 +54,12 @@ class ServicesV3(object):
         client = req.env['sl_client']
         account = client['Account'].getObject()
 
-        tenants = [{
-            'enabled': True,
-            'description': None,
-            'name': str(account['id']),
-            'id': str(account['id']),
-            }]
+        # tenants = [{
+        #    'enabled': True,
+        #    'description': None,
+        #    'name': str(account['id']),
+        #    'id': str(account['id']),
+        #    }]
 
         # Add catalog to the access data
         raw_catalog = self._get_catalog(account['id'], account['id'])

--- a/jumpgate/identity/drivers/sl/servicesV3.py
+++ b/jumpgate/identity/drivers/sl/servicesV3.py
@@ -12,8 +12,6 @@ from oslo.config import cfg
 LOG = logging.getLogger(__name__)
 
 
-
-
 def parse_templates(template_lines):
     o = {}
     for line in template_lines:
@@ -37,6 +35,7 @@ def parse_templates(template_lines):
 
     return o
 
+
 class ServicesV3(object):
     def __init__(self, template_file):
         self._load_templates(template_file)
@@ -59,18 +58,17 @@ class ServicesV3(object):
                 for k, v in service_ref.items():
                     o[region][service][k] = v.replace('$(', '%(') % d
         return o
+
     def on_get(self, req, resp):
         client = req.env['sl_client']
         account = client['Account'].getObject()
 
-        tenants = [
-            {
-                'enabled': True,
-                'description': None,
-                'name': str(account['id']),
-                'id': str(account['id']),
-            },
-        ]
+        tenants = [{
+            'enabled': True,
+            'description': None,
+            'name': str(account['id']),
+            'id': str(account['id']),
+            }]
 
         # Add catalog to the access data
         raw_catalog = self._get_catalog(account['id'], account['id'])

--- a/jumpgate/identity/drivers/sl/tokens.py
+++ b/jumpgate/identity/drivers/sl/tokens.py
@@ -86,7 +86,7 @@ class SLAuthDriver(identity.AuthDriver):
             username = token_driver.username(token)
             credential = token_driver.credential(token)
             return {'user': user, 'credential': credential,
-                    'auth_type': token['auth_type'] }
+                    'auth_type': token['auth_type']}
 
         def assert_tenant(user):
             tenant = lookup(creds, 'auth', 'tenantId') or lookup(creds,

--- a/jumpgate/identity/drivers/sl/userProjectsV3.py
+++ b/jumpgate/identity/drivers/sl/userProjectsV3.py
@@ -1,21 +1,22 @@
 from jumpgate.common.error_handling import error
 
+
 class UserProjectsV3(object):
     def on_get(self, req, resp, user_id):
         client = req.env['sl_client']
         account = client['Account'].getObject()
         currentUser = client['Account'].getCurrentUser()
-        if currentUser['username']!=user_id:
-            return error(resp, 'notMatch', 'User provided does not match current user', details=None, code=500)
+        if currentUser['username'] != user_id:
+            return error(resp, 'notMatch',
+                         'User provided does not match current user',
+                         details=None, code=500)
 
-        projects = [
-            {
-                'domain_id':str(account['id']),
-                'enabled': True,
-                'description': None,
-                'name': currentUser['username'],
-                'id': str(account['id']),
-            },
-        ]
+        projects = [{
+            'domain_id': str(account['id']),
+            'enabled': True,
+            'description': None,
+            'name': currentUser['username'],
+            'id': str(account['id']),
+            }]
 
         resp.body = {'projects': projects, 'tenant_links': []}

--- a/jumpgate/identity/drivers/sl/userProjectsV3.py
+++ b/jumpgate/identity/drivers/sl/userProjectsV3.py
@@ -1,0 +1,21 @@
+from jumpgate.common.error_handling import error
+
+class UserProjectsV3(object):
+    def on_get(self, req, resp, user_id):
+        client = req.env['sl_client']
+        account = client['Account'].getObject()
+        currentUser = client['Account'].getCurrentUser()
+        if currentUser['username']!=user_id:
+            return error(resp, 'notMatch', 'User provided does not match current user', details=None, code=500)
+
+        projects = [
+            {
+                'domain_id':str(account['id']),
+                'enabled': True,
+                'description': None,
+                'name': currentUser['username'],
+                'id': str(account['id']),
+            },
+        ]
+
+        resp.body = {'projects': projects, 'tenant_links': []}

--- a/jumpgate/identity/drivers/sl/v3.py
+++ b/jumpgate/identity/drivers/sl/v3.py
@@ -1,0 +1,23 @@
+class V3(object):
+    def __init__(self, disp):
+        self.disp = disp
+
+    def on_get(self, req, resp):
+        resp.body = {"version":{
+      "status":"stable",
+      "updated":"2013-03-06T00:00:00Z",
+      "media-types":[
+         {
+            "base":"application/json",
+            "type":"application/vnd.openstack.identity-v3+json"
+         }
+      ],
+      "id":"v3.0",
+      "links":[
+         {
+            "href":self.disp.get_endpoint_url(req, 'v3_auth_index'),
+            "rel":"self"
+         }
+      ]
+   }
+}

--- a/jumpgate/identity/drivers/sl/v3.py
+++ b/jumpgate/identity/drivers/sl/v3.py
@@ -1,23 +1,20 @@
 class V3(object):
+
     def __init__(self, disp):
         self.disp = disp
 
     def on_get(self, req, resp):
-        resp.body = {"version":{
-      "status":"stable",
-      "updated":"2013-03-06T00:00:00Z",
-      "media-types":[
-         {
-            "base":"application/json",
-            "type":"application/vnd.openstack.identity-v3+json"
-         }
-      ],
-      "id":"v3.0",
-      "links":[
-         {
-            "href":self.disp.get_endpoint_url(req, 'v3_auth_index'),
-            "rel":"self"
-         }
-      ]
-   }
-}
+        resp.body = {"version": {
+            "status": "stable",
+            "updated": "2013-03-06T00:00:00Z",
+            "media-types": [{
+                "base": "application/json",
+                "type": "application/vnd.openstack.identity-v3+json"
+                }],
+            "id": "v3.0",
+            "links": [{
+                "href": self.disp.get_endpoint_url(req, 'v3_auth_index'),
+                "rel": "self"
+                }]
+            }
+        }

--- a/jumpgate/identity/drivers/sl/versions.py
+++ b/jumpgate/identity/drivers/sl/versions.py
@@ -9,6 +9,39 @@ class Versions(object):
             'versions': {
                 'values': [
                     {
+                        'id': 'v3.0',
+                        'links': [
+                            {
+                                'href': self.disp.get_endpoint_url(
+                                    req, 'v3_auth_index'),
+                                'rel': 'self'
+                            },
+                            {
+                                'href': 'http://docs.openstack.org/api/'
+                                        'openstack-identity-service/3/'
+                                        'content/',
+                                'rel': 'describedby',
+                                'type': 'text/html'
+                            },
+                            {
+                                'href': 'http://docs.openstack.org/api/'
+                                        'openstack-identity-service/3/'
+                                        'identity-api-ref-3.pdf',
+                                'rel': 'describedby',
+                                'type': 'application/pdf'
+                            }
+                        ],
+                        'media-types': [
+                            {
+                                'base': 'application/json',
+                                'type': 'application/'
+                                        'vnd.openstack.identity-v3+json'
+                            }
+                        ],
+                        'status': 'stable',
+                        'updated': '2014-04-17T00:00:00Z'
+                    },
+                    {
                         'id': 'v2.0',
                         'links': [
                             {

--- a/tests/softlayer/identity_v3.templates
+++ b/tests/softlayer/identity_v3.templates
@@ -1,0 +1,29 @@
+catalog.RegionOne.identity.name = Identity Service
+catalog.RegionOne.identity.publicURL = http://localhost:5000/v3
+catalog.RegionOne.identity.privateURL = http://localhost:5000/v3
+catalog.RegionOne.identity.adminURL = http://localhost:5000/v3
+
+catalog.RegionOne.baremetal.name = Bare Metal Service
+catalog.RegionOne.baremetal.publicURL = http://localhost:5000/v3/baremetal
+catalog.RegionOne.baremetal.privateURL = http://localhost:5000/v3/baremetal
+catalog.RegionOne.baremetal.adminURL = http://localhost:5000/v3/baremetal
+
+catalog.RegionOne.compute.name = Compute Service
+catalog.RegionOne.compute.publicURL = http://localhost:5000/compute/v3/$(tenant_id)s
+catalog.RegionOne.compute.privateURL = http://localhost:5000/compute/v3/$(tenant_id)s
+catalog.RegionOne.compute.adminURL = http://localhost:5000/compute/v3/$(tenant_id)s
+
+catalog.RegionOne.image.name = Image Service
+catalog.RegionOne.image.publicURL = http://localhost:5000/image/v3
+catalog.RegionOne.image.privateURL = http://localhost:5000/image/v3
+catalog.RegionOne.image.adminURL = http://localhost:5000/image/v3
+
+catalog.RegionOne.network.name = Image Service
+catalog.RegionOne.network.publicURL = http://localhost:5000/network/
+catalog.RegionOne.network.privateURL = http://localhost:5000/network/
+catalog.RegionOne.network.adminURL = http://localhost:5000/network/
+
+#catalog.RegionOne.volume.name = Block Storage Service
+#catalog.RegionOne.volume.publicURL = http://localhost:5000/volume/v1/$(tenant_id)s
+#catalog.RegionOne.volume.privateURL = http://localhost:5000/volume/v1/$(tenant_id)s
+#catalog.RegionOne.volume.adminURL = http://localhost:5000/volume/v1/$(tenant_id)s

--- a/tests/softlayer/test_dispatchers.py
+++ b/tests/softlayer/test_dispatchers.py
@@ -10,6 +10,8 @@ DIR_PATH = os.path.dirname(__file__)
 MOCK_CONFIG = MagicMock()
 MOCK_CONFIG.softlayer.catalog_template_file = os.path.join(
     DIR_PATH, 'identity.templates')
+MOCK_CONFIG.softlayer.catalog_template_file_v3 = os.path.join(
+    DIR_PATH, 'identity_v3.templates')
 
 
 class TestServiceDispatchers(unittest.TestCase):


### PR DESCRIPTION
This is a combination of the Issue 49 (Identity version 3 implementation) that srinivaa developed with additional tokens & service/users support needed to support using Heat against Jumpgate.  The additional Identity-V3 code was developed by Bill Arnold (IBM) and debugged/tweaked by myself.  I would recommend this replace the existing Issue 49 pull request since it has the same function and more.

I was able to test this against a standalone dev-stack Heat of IceHouse release where I could perform: “heat —include-password stack-create -f OneVM.hot”

The HOT file was:

```
heat_template_version: '2013-05-23'
description: Single CCI instance
resources:
  WCA-VM1:
    type: OS::Nova::Server
    properties:
      key_name: 'acmeair-netflix'
      flavor: '2'
      image: 'b2debf0a-6bcf-4a02-8d9e-b382806c4b00'
      user_data_format: 'RAW'
```

It was not clear in issue 49 what the “pluggable auth” changes that sudorandom wanted, but I’m assuming he could merge those same changes against this pull request. 
