### PR TITLE
Correct http return code of identify versions api

### DIFF
--- a/jumpgate/identity/drivers/sl/versions.py
+++ b/jumpgate/identity/drivers/sl/versions.py
@@ -1,3 +1,4 @@
+import falcon
 
 
 class Versions(object):
@@ -5,6 +6,7 @@ class Versions(object):
         self.disp = disp
 
     def on_get(self, req, resp):
+        resp.status = falcon.HTTP_300
         resp.body = {
             'versions': {
                 'values': [


### PR DESCRIPTION
Keystone returns 300 http code (Multiple Choices) instead of 200 (OK)
[0] when client GETs the api version info that current identify service
supported.

This wrong return code causes keystonemiddleware failed at api version
query [1] with error "Unable to get version info from keystone: 200",
which middleware as a client of keystone lives in a upperlayer service.

[0]
https://github.com/openstack/keystone/blob/master/keystone/controllers.py#L132
[1]
https://github.com/openstack/keystonemiddleware/blob/master/keystonemiddleware/auth_token.py#L1245

For the details of curl test, see
http://paste.openstack.org/show/92177/ .

Signed-off-by: Zhi Yan Liu zhiyanl@cn.ibm.com
