### PR TITLE
Making token validation api returns service catalog

### DIFF
--- a/jumpgate/identity/drivers/sl/__init__.py
+++ b/jumpgate/identity/drivers/sl/__init__.py
@@ -16,13 +16,6 @@ def setup_routes(app, disp):
     disp.set_handler('v3_auth_index', v3.V3(disp))
     disp.set_handler('v3_user_projects', user_projects_v3.UserProjectsV3())
 
-    # V2 Routes
-    disp.set_handler('v2_tenants', tenants.TenantsV2())
-    disp.set_handler('v2_token', tokens.TokenV2())
-    disp.set_handler('v2_user', user.UserV2())
-
-    disp.set_handler('versions', versions.Versions(disp))
-
     template_file = app.config.softlayer.catalog_template_file
     if not os.path.exists(template_file):
         template_file = app.config.find_file(template_file)
@@ -36,6 +29,13 @@ def setup_routes(app, disp):
 
     if template_file_v3 is None:
         raise ValueError('Template file v3 not found')
+
+    # V2 Routes
+    disp.set_handler('v2_tenants', tenants.TenantsV2())
+    disp.set_handler('v2_token', tokens.TokenV2(template_file))
+    disp.set_handler('v2_user', user.UserV2())
+
+    disp.set_handler('versions', versions.Versions(disp))
 
     disp.set_handler('v2_tokens', tokens.TokensV2(template_file))
     disp.set_handler('v2_token_endpoints', tokens.TokensV2(template_file))


### PR DESCRIPTION
Currently access info token validation api returned doesn't include
service catalog dict, it causes some projects couldn't work well as it
designed: upperlayer project uses those endpoints to call other servies
for the necessary handling of function, e.g. Heat, as an example the
follow execution stack could be triggered by a standard stack creation
usecase. And, as code logic shown, keystoneclient has such related
parsing and construction logic as well.

https://github.com/openstack/heat/blob/master/heat/engine/properties.py#L296
  https://github.com/openstack/heat/blob/master/heat/engine/constraints.py#L576
    https://github.com/openstack/heat/blob/master/heat/engine/clients/os/glance.py#L35
      https://github.com/openstack/heat/blob/master/heat/engine/clients/client_plugin.py#L50
        https://github.com/openstack/heat/blob/master/heat/common/heat_keystoneclient.py#L196
          https://github.com/openstack/python-keystoneclient/blob/master/keystoneclient/httpclient.py#L174
            https://github.com/openstack/python-keystoneclient/blob/master/keystoneclient/access.py#L532
              https://github.com/openstack/python-keystoneclient/blob/master/keystoneclient/service_catalog.py#L271

Signed-off-by: Zhi Yan Liu zhiyanl@cn.ibm.com
