### PR TITLE
Correct content type of response for image metadata getting api

### DIFF
--- a/jumpgate/image/drivers/sl/images.py
+++ b/jumpgate/image/drivers/sl/images.py
@@ -221,6 +221,7 @@ class ImageV1(object):
         }
 
         resp.set_headers(headers)
+        resp.content_type = 'text/html; charset=utf-8'
 
 
 class ImagesV1(ImagesV2):


### PR DESCRIPTION
The recent change [0] makes glanceclient use requests to communicate
with glance server, new http handling logic of which is sensitive on the
content type of response [1].

But current jumpgate logic for the api doesn't return any content by
http body [2] but with 'application/json' content type [3]. Then it
broken that new glanceclient logic and trigger error: "Multiple image
matches found for '<IMAGE_ID>', use an ID to be more specific.".

[0]
https://github.com/openstack/python-glanceclient/commit/dbb242b776908ca50ed8557ebfe7cfcd879366c8
[1]
https://github.com/openstack/python-glanceclient/blob/master/glanceclient/common/http.py#L218
[2]
https://github.com/softlayer/jumpgate/blob/master/jumpgate/image/drivers/sl/images.py#L223
[3] https://github.com/racker/falcon/blob/master/falcon/__init__.py#L27

Signed-off-by: Zhi Yan Liu zhiyanl@cn.ibm.com
