### PR TITLE
Enabling name filter on image metadata api

### DIFF
--- a/jumpgate/image/drivers/sl/images.py
+++ b/jumpgate/image/drivers/sl/images.py
@@ -145,10 +145,16 @@ class ImagesV2(object):
 
         images = []
         for image in get_all_images(client):
-            images.append(get_v2_image_details_dict(self.app,
-                                                    req,
-                                                    image,
-                                                    tenant_id))
+            img = get_v2_image_details_dict(self.app, req, image, tenant_id)
+
+            # Apply conditions from filters
+            # TODO(zhiyan): Will add more filters continuously
+            # with requirement-driven way.
+            if req.get_param('name'):
+                if img['name'] != req.get_param('name'):
+                    continue
+
+            images.append(img)
 
         sorted_images = sorted(images, key=lambda x: x['id'].lower())
         if req.get_param('marker'):

--- a/tests/jumpgate-tests/image/test_images.py
+++ b/tests/jumpgate-tests/image/test_images.py
@@ -163,3 +163,40 @@ class TestImagesV2(unittest.TestCase):
         self.assertEquals(image2['id'], 'uuid2')
         self.assertEquals(image2['name'], 'some other image')
         self.assertEquals(image2['size'], 2000)
+
+    def test_on_get_with_name_filter(self):
+        client, env = get_client_env(query_string='name=imageA')
+        vgbdtg = client['Virtual_Guest_Block_Device_Template_Group']
+        vgbdtg.getPublicImages.return_value = [{
+            'globalIdentifier': 'uuid',
+            'blockDevicesDiskSpaceTotal': 1000,
+            'name': 'imageA',
+        }]
+        client['Account'].getPrivateBlockDeviceTemplateGroups.return_value = [{
+            'globalIdentifier': 'uuid2',
+            'blockDevicesDiskSpaceTotal': 2000,
+            'name': 'imageB',
+        }]
+
+        # 1. There is one image pass the filter and returned in result.
+        req = falcon.Request(env)
+        resp = falcon.Response()
+
+        images.ImagesV2(self.app).on_get(req, resp)
+
+        self.assertEquals(resp.status, 200)
+        self.assertEquals(len(resp.body['images']), 1)
+        image1 = resp.body['images'][0]
+        self.assertEquals(image1['id'], 'uuid')
+        self.assertEquals(image1['name'], 'imageA')
+        self.assertEquals(image1['size'], 1000)
+
+        # 2. There is no any image could pass the filter and been returned.
+        __client, env = get_client_env(query_string='name=imageX')
+        req = falcon.Request(env)
+        resp = falcon.Response()
+
+        images.ImagesV2(self.app).on_get(req, resp)
+
+        self.assertEquals(resp.status, 200)
+        self.assertEquals(len(resp.body['images']), 0)


### PR DESCRIPTION
To enable filter function for image v1 and v2 metadata api, which fixed
issue "Multiple image matches found for '<IMAGE_NAME>', use an ID to be
more specific." caused by that jumpgate returns all images without name
based filter when glanceclient request a image metadata query [0].

[0]
https://github.com/openstack/python-glanceclient/blob/master/glanceclient/common/utils.py#L159

Signed-off-by: Zhi Yan Liu zhiyanl@cn.ibm.com
