### PR TITLE
Correct authentication and token generation v3 api

### DIFF
--- a/jumpgate/common/hooks/auth_token.py
+++ b/jumpgate/common/hooks/auth_token.py
@@ -9,7 +9,7 @@ from jumpgate.identity.drivers import core as identity
 LOG = logging.getLogger(__name__)
 NOAUTH = [re.compile(e) for e in ['GET:/$', 'GET:\/v[\d]+[\/]?$',
                                   'GET:\/v[\d]+.[\d]+[\/]?$',
-                                  'POST:\/v[\d]+\/tokens$',
+                                  'POST:\/v[\d]+\/auth/tokens$',
                                   'POST:\/v[\d]+.[\d]+\/tokens$',
                                   'GET:\/v[\d]+\/tokens/\w+$',
                                   'GET:\/v[\d]+.[\d]+\/tokens/\w+$']]

--- a/jumpgate/common/sl/auth.py
+++ b/jumpgate/common/sl/auth.py
@@ -54,11 +54,15 @@ def get_new_token_v3(credentials):
 
     username = utils.lookup(credentials,
                             'auth',
-                            'passwordCredentials',
-                            'username')
+                            'identity',
+                            'password',
+                            'user',
+                            'name')
     credential = utils.lookup(credentials,
                               'auth',
-                              'passwordCredentials',
+                              'identity',
+                              'password',
+                              'user',
                               'password')
 
     # If the 'password' is the right length, treat it as an API api_key

--- a/jumpgate/identity/__init__.py
+++ b/jumpgate/identity/__init__.py
@@ -6,10 +6,9 @@ def add_endpoints(disp):
     # V3 API - http://api.openstack.org/api-ref-identity.html#identity-v3
 
     disp.add_endpoint('v3_auth_index', '/v3')
-    # Tokens
 
+    # Tokens
     disp.add_endpoint('v3_auth_tokens', '/v3/auth/tokens')
-    disp.add_endpoint('v3_tokens', '/v3/tokens')
 
     # Service Catalog
     disp.add_endpoint('v3_services', '/v3/services')

--- a/tests/jumpgate-tests/common/hooks/test_hooks.py
+++ b/tests/jumpgate-tests/common/hooks/test_hooks.py
@@ -91,8 +91,9 @@ class TestHookAuthToken(unittest.TestCase):
 
     def test_unprotected(self):
         for api in ['GET:/v2', 'GET:/v2/', 'GET:/v3.0', 'GET:/v3.0/',
-                    'GET:/v10.22', 'POST:/v2/tokens', 'POST:/v2.1/tokens',
-                    'GET:/v2/tokens/a8Vs7bS', 'GET:/v2.0/tokens/a8Vs7bS']:
+                    'GET:/v10.22', 'POST:/v2.0/tokens', 'POST:/v2.1/tokens',
+                    'GET:/v2/tokens/a8Vs7bS', 'GET:/v2.0/tokens/a8Vs7bS',
+                    'POST:/v3/auth/tokens']:
             req = MagicMock()
             req.headers = {'X-AUTH-TOKEN': None}
             req.method = api.split(':')[0]


### PR DESCRIPTION
1. Remove a wrong route mapper for '/v3/tokens' path.
2. Correct NOAUTH list to include path of authentication and token
   generation v3 api.
3. Correct authentication implementation of the api.
