### PR TITLE
Adding token validation api for v3 identity api

### DIFF
--- a/jumpgate/identity/drivers/sl/auth_tokens_v3.py
+++ b/jumpgate/identity/drivers/sl/auth_tokens_v3.py
@@ -8,6 +8,7 @@ import SoftLayer
 
 from jumpgate.common import aes
 from jumpgate.common.sl import auth
+from jumpgate.identity.drivers import core as identity
 
 LOG = logging.getLogger(__name__)
 
@@ -60,7 +61,7 @@ def get_access(token_id, token_details, user):
     }
 
 
-def get_access_v3(token_id, token_details, user):
+def get_access_v3(token_id, token_details, user_id, user_name):
     return {
         'token': {
             'expires_at': datetime.datetime.fromtimestamp(
@@ -69,10 +70,24 @@ def get_access_v3(token_id, token_details, user):
                 token_details['expires']).isoformat(),
             'methods': ['password'],
             'id': token_id,
-            'user': {
-                'id': user['id'],
+            'project': {
+                'id': token_details['tenant_id'],
                 'links': [0],
-                'name': user['username']}
+                'name': token_details['tenant_id'],
+                'domain': {
+                    'id': 'default',
+                    'links': [0],
+                    'name': 'Default'}
+            },
+            'user': {
+                'id': user_id,
+                'links': [0],
+                'name': user_name,
+                'domain': {
+                    'id': 'default',
+                    'links': [0],
+                    'name': 'Default'}
+            }
         }
     }
 
@@ -100,8 +115,8 @@ class AuthTokensV3(object):
                     o[region][service][k] = v.replace('$(', '%(') % d
         return o
 
-    def _build_catalog(self, token_details, user):
-        raw_catalog = self._get_catalog(token_details['tenant_id'], user['id'])
+    def _build_catalog(self, token_details, user_id):
+        raw_catalog = self._get_catalog(token_details['tenant_id'], user_id)
         catalog = []
         for services in raw_catalog.values():
             for service_type, service in services.items():
@@ -135,13 +150,42 @@ class AuthTokensV3(object):
         token_details, user = auth.get_new_token_v3(credentials)
         token_id = base64.b64encode(aes.encode_aes(json.dumps(token_details)))
 
-        access = get_access_v3(token_id, token_details, user)
+        access = get_access_v3(token_id, token_details,
+                               user['id'], user['username'])
         # Add catalog to the access data
-        catalog = self._build_catalog(token_details, user)
+        catalog = self._build_catalog(token_details, user['id'])
         access['token']['catalog'] = catalog
 
         resp.status = 200
         resp.set_header('X-Subject-Token', str(token_id))
+        # V2 APIs return the body in 'access' keypair but V3 APIs do not
+        # resp.body = {'access': access}
+        resp.body = access
+
+    def on_get(self, req, resp):
+        toks = [req.get_header('X-Auth-Token'),  # the token who sent request
+                req.get_header('X-Subject-Token')]  # the token to be validated
+        token_id_driver = identity.token_id_driver()
+        tokens = identity.token_driver()
+        validated_tokens = []
+        for token_id in toks:
+            token = token_id_driver.token_from_id(token_id)
+            tokens.validate_token(token)
+            validated_tokens.append(token)
+
+        access = get_access_v3(toks[1], validated_tokens[1],
+                               tokens.user_id(validated_tokens[1]),
+                               tokens.username(validated_tokens[1]))
+
+        if 'nocatalog' not in req.query_string:
+            # Add catalog to the access data
+            catalog = self._build_catalog(validated_tokens[1],
+                                          tokens.user_id(validated_tokens[1]))
+            access['token']['catalog'] = catalog
+
+        resp.status = 200
+        resp.set_header('X-Auth-Token', toks[0])
+        resp.set_header('X-Subject-Token', toks[1])
         # V2 APIs return the body in 'access' keypair but V3 APIs do not
         # resp.body = {'access': access}
         resp.body = access


### PR DESCRIPTION
This change impleneted token valication api which is a major function as
a part of v3 identity api, some upper layer components used this
interface to validate v3 token.

An action handling function has been added which is used to handle the
http request received on /v3/auth/tokens endpoint with GET method.

Signed-off-by: Zhi Yan Liu zhiyanl@cn.ibm.com
