### PR TITLE
Correct region name of service catalog for identity V2 API

### DIFF
--- a/jumpgate/identity/drivers/sl/tokens.py
+++ b/jumpgate/identity/drivers/sl/tokens.py
@@ -33,6 +33,7 @@ def parse_templates(template_lines):
         region_ref = o.get(region, {})
         service_ref = region_ref.get(service, {})
         service_ref[key] = v
+        service_ref['region'] = region
 
         region_ref[service] = service_ref
         o[region] = region_ref


### PR DESCRIPTION
Currently the code of service catalog construction has a defect which
caused operator configured region name could not be able to apply into
the response of service catalog in such identity V2 APIs, and
"RegionOne" were used in any case [0] instead.

[0]
https://github.com/softlayer/jumpgate/blob/master/jumpgate/identity/drivers/sl/tokens.py#L210

Signed-off-by: Zhi Yan Liu zhiyanl@cn.ibm.com
