### PR TITLE
Correct name of internal URL in endpoints and template

### DIFF
--- a/etc/identity.templates
+++ b/etc/identity.templates
@@ -1,30 +1,30 @@
 
 catalog.RegionOne.identity.name = Identity Service
 catalog.RegionOne.identity.publicURL = http://localhost:5000/v2.0
-catalog.RegionOne.identity.privateURL = http://localhost:5000/v2.0
+catalog.RegionOne.identity.internalURL = http://localhost:5000/v2.0
 catalog.RegionOne.identity.adminURL = http://localhost:5000/v2.0
 
 catalog.RegionOne.baremetal.name = Bare Metal Service
 catalog.RegionOne.baremetal.publicURL = http://localhost:5000/v2/baremetal
-catalog.RegionOne.baremetal.privateURL = http://localhost:5000/v2/baremetal
+catalog.RegionOne.baremetal.internalURL = http://localhost:5000/v2/baremetal
 catalog.RegionOne.baremetal.adminURL = http://localhost:5000/v2/baremetal
 
 catalog.RegionOne.compute.name = Compute Service
 catalog.RegionOne.compute.publicURL = http://localhost:5000/compute/v2/$(tenant_id)s
-catalog.RegionOne.compute.privateURL = http://localhost:5000/compute/v2/$(tenant_id)s
+catalog.RegionOne.compute.internalURL = http://localhost:5000/compute/v2/$(tenant_id)s
 catalog.RegionOne.compute.adminURL = http://localhost:5000/compute/v2/$(tenant_id)s
 
 catalog.RegionOne.image.name = Image Service
 catalog.RegionOne.image.publicURL = http://localhost:5000/image
-catalog.RegionOne.image.privateURL = http://localhost:5000/image
+catalog.RegionOne.image.internalURL = http://localhost:5000/image
 catalog.RegionOne.image.adminURL = http://localhost:5000/image
 
 catalog.RegionOne.network.name = Network Service
 catalog.RegionOne.network.publicURL = http://localhost:5000/network
-catalog.RegionOne.network.privateURL = http://localhost:5000/network
+catalog.RegionOne.network.internalURL = http://localhost:5000/network
 catalog.RegionOne.network.adminURL = http://localhost:5000/network
 
 catalog.RegionOne.volume.name = Block Storage Service
 catalog.RegionOne.volume.publicURL = http://localhost:5000/volume/v1/$(tenant_id)s
-catalog.RegionOne.volume.privateURL = http://localhost:5000/volume/v1/$(tenant_id)s
+catalog.RegionOne.volume.internalURL = http://localhost:5000/volume/v1/$(tenant_id)s
 catalog.RegionOne.volume.adminURL = http://localhost:5000/volume/v1/$(tenant_id)s

--- a/etc/identity_v3.templates
+++ b/etc/identity_v3.templates
@@ -1,30 +1,30 @@
 
 catalog.RegionOne.identity.name = Identity Service
 catalog.RegionOne.identity.publicURL = http://localhost:5000/v3
-catalog.RegionOne.identity.privateURL = http://localhost:5000/v3
+catalog.RegionOne.identity.internalURL = http://localhost:5000/v3
 catalog.RegionOne.identity.adminURL = http://localhost:5000/v3
 
 catalog.RegionOne.baremetal.name = Bare Metal Service
 catalog.RegionOne.baremetal.publicURL = http://localhost:5000/v2/baremetal
-catalog.RegionOne.baremetal.privateURL = http://localhost:5000/v2/baremetal
+catalog.RegionOne.baremetal.internalURL = http://localhost:5000/v2/baremetal
 catalog.RegionOne.baremetal.adminURL = http://localhost:5000/v2/baremetal
 
 catalog.RegionOne.compute.name = Compute Service
 catalog.RegionOne.compute.publicURL = http://localhost:5000/compute/v2/$(tenant_id)s
-catalog.RegionOne.compute.privateURL = http://localhost:5000/compute/v2/$(tenant_id)s
+catalog.RegionOne.compute.internalURL = http://localhost:5000/compute/v2/$(tenant_id)s
 catalog.RegionOne.compute.adminURL = http://localhost:5000/compute/v2/$(tenant_id)s
 
 catalog.RegionOne.image.name = Image Service
 catalog.RegionOne.image.publicURL = http://localhost:5000/image/v2
-catalog.RegionOne.image.privateURL = http://localhost:5000/image/v2
+catalog.RegionOne.image.internalURL = http://localhost:5000/image/v2
 catalog.RegionOne.image.adminURL = http://localhost:5000/image/v2
 
 catalog.RegionOne.network.name = Image Service
 catalog.RegionOne.network.publicURL = http://localhost:5000/network/
-catalog.RegionOne.network.privateURL = http://localhost:5000/network/
+catalog.RegionOne.network.internalURL = http://localhost:5000/network/
 catalog.RegionOne.network.adminURL = http://localhost:5000/network/
 
 catalog.RegionOne.volume.name = Block Storage Service
 catalog.RegionOne.volume.publicURL = http://localhost:5000/volume/v1/$(tenant_id)s
-catalog.RegionOne.volume.privateURL = http://localhost:5000/volume/v1/$(tenant_id)s
+catalog.RegionOne.volume.internalURL = http://localhost:5000/volume/v1/$(tenant_id)s
 catalog.RegionOne.volume.adminURL = http://localhost:5000/volume/v1/$(tenant_id)s

--- a/jumpgate/identity/drivers/sl/auth_tokens_v3.py
+++ b/jumpgate/identity/drivers/sl/auth_tokens_v3.py
@@ -128,7 +128,7 @@ class AuthTokensV3(object):
                         # 'id': "????"
                         'interface': "internal",
                         'region': service.get('region', 'RegionOne'),
-                        'url': service.get('privateURL')
+                        'url': service.get('internalURL')
                     }, {
                         # 'id': "????"
                         'interface': "public",

--- a/jumpgate/identity/drivers/sl/services_v3.py
+++ b/jumpgate/identity/drivers/sl/services_v3.py
@@ -72,7 +72,7 @@ class ServicesV3(object):
                     'endpoints': [{
                         'region': service.get('region', 'RegionOne'),
                         'publicURL': service.get('publicURL'),
-                        'privateURL': service.get('privateURL'),
+                        'internalURL': service.get('internalURL'),
                         'adminURL': service.get('adminURL'),
                     }],
                     'endpoint_links': [],

--- a/jumpgate/identity/drivers/sl/tokens.py
+++ b/jumpgate/identity/drivers/sl/tokens.py
@@ -210,7 +210,7 @@ class TokensV2(object):
                     'endpoints': [{
                         'region': service.get('region', 'RegionOne'),
                         'publicURL': service.get('publicURL'),
-                        'privateURL': service.get('privateURL'),
+                        'internalURL': service.get('internalURL'),
                         'adminURL': service.get('adminURL'),
                     }],
                     'endpoint_links': [],
@@ -249,7 +249,7 @@ class TokensV2(object):
                     'adminURL': service.get('adminURL'),
                     'name': service.get('name', 'Unknown'),
                     'publicURL': service.get('publicURL'),
-                    'privateURL': service.get('privateURL'),
+                    'internalURL': service.get('internalURL'),
                     'region': service.get('region', 'RegionOne'),
                     'tenantId': tokens.tenant_id(token),
                     'type': service_type,

--- a/tests/jumpgate-tests/identity.templates
+++ b/tests/jumpgate-tests/identity.templates
@@ -1,24 +1,24 @@
 
 catalog.RegionOne.identity.name = Identity Service
 catalog.RegionOne.identity.publicURL = http://localhost:5000/v2.0
-catalog.RegionOne.identity.privateURL = http://localhost:5000/v2.0
+catalog.RegionOne.identity.internalURL = http://localhost:5000/v2.0
 
 catalog.RegionOne.baremetal.name = Bare Metal Service
 catalog.RegionOne.baremetal.publicURL = http://localhost:5000/v2/baremetal
-catalog.RegionOne.baremetal.privateURL = http://localhost:5000/v2/baremetal
+catalog.RegionOne.baremetal.internalURL = http://localhost:5000/v2/baremetal
 
 catalog.RegionOne.compute.name = Compute Service
 catalog.RegionOne.compute.publicURL = http://localhost:5000/compute/v2/$(tenant_id)s
-catalog.RegionOne.compute.privateURL = http://localhost:5000/compute/v2/$(tenant_id)s
+catalog.RegionOne.compute.internalURL = http://localhost:5000/compute/v2/$(tenant_id)s
 
 catalog.RegionOne.image.name = Image Service
 catalog.RegionOne.image.publicURL = http://localhost:5000/image/v2
-catalog.RegionOne.image.privateURL = http://localhost:5000/image/v2
+catalog.RegionOne.image.internalURL = http://localhost:5000/image/v2
 
 catalog.RegionOne.network.name = Image Service
 catalog.RegionOne.network.publicURL = http://localhost:5000/network/v2
-catalog.RegionOne.network.privateURL = http://localhost:5000/network/v2
+catalog.RegionOne.network.internalURL = http://localhost:5000/network/v2
 
 #catalog.RegionOne.volume.name = Block Storage Service
 #catalog.RegionOne.volume.publicURL = http://localhost:5000/volume/v1/$(tenant_id)s
-#catalog.RegionOne.volume.privateURL = http://localhost:5000/volume/v1/$(tenant_id)s
+#catalog.RegionOne.volume.internalURL = http://localhost:5000/volume/v1/$(tenant_id)s

--- a/tests/jumpgate-tests/identity_v3.templates
+++ b/tests/jumpgate-tests/identity_v3.templates
@@ -1,30 +1,30 @@
  
  catalog.RegionOne.identity.name = Identity Service
  catalog.RegionOne.identity.publicURL = http://localhost:5000/v3
- catalog.RegionOne.identity.privateURL = http://localhost:5000/v3
+ catalog.RegionOne.identity.internalURL = http://localhost:5000/v3
  catalog.RegionOne.identity.adminURL = http://localhost:5000/v3
 
  catalog.RegionOne.baremetal.name = Bare Metal Service
  catalog.RegionOne.baremetal.publicURL = http://localhost:5000/v2/baremetal
- catalog.RegionOne.baremetal.privateURL = http://localhost:5000/v2/baremetal
+ catalog.RegionOne.baremetal.internalURL = http://localhost:5000/v2/baremetal
  catalog.RegionOne.baremetal.adminURL = http://localhost:5000/v2/baremetal
 
  catalog.RegionOne.compute.name = Compute Service
  catalog.RegionOne.compute.publicURL = http://localhost:5000/compute/v2/$(tenant_id)s
- catalog.RegionOne.compute.privateURL = http://localhost:5000/compute/v2/$(tenant_id)s
+ catalog.RegionOne.compute.internalURL = http://localhost:5000/compute/v2/$(tenant_id)s
  catalog.RegionOne.compute.adminURL = http://localhost:5000/compute/v2/$(tenant_id)s
 
  catalog.RegionOne.image.name = Image Service
  catalog.RegionOne.image.publicURL = http://localhost:5000/image/v2
- catalog.RegionOne.image.privateURL = http://localhost:5000/image/v2
+ catalog.RegionOne.image.internalURL = http://localhost:5000/image/v2
  catalog.RegionOne.image.adminURL = http://localhost:5000/image/v2
 
  catalog.RegionOne.network.name = Image Service
  catalog.RegionOne.network.publicURL = http://localhost:5000/network/
- catalog.RegionOne.network.privateURL = http://localhost:5000/network/
+ catalog.RegionOne.network.internalURL = http://localhost:5000/network/
  catalog.RegionOne.network.adminURL = http://localhost:5000/network/
 
 #catalog.RegionOne.volume.name = Block Storage Service
 #catalog.RegionOne.volume.publicURL = http://localhost:5000/volume/v1/$(tenant_id)s
-#catalog.RegionOne.volume.privateURL = http://localhost:5000/volume/v1/$(tenant_id)s
+#catalog.RegionOne.volume.internalURL = http://localhost:5000/volume/v1/$(tenant_id)s
 #catalog.RegionOne.volume.adminURL = http://localhost:5000/volume/v1/$(tenant_id)s


### PR DESCRIPTION
Base on the identity api speces [0][1], internal URL of a service
should be provided by 'internalURL' key instead of 'privateURL'.

[0] http://developer.openstack.org/api-ref-identity-v2.html
[1] http://developer.openstack.org/api-ref-identity-v3.html

Signed-off-by: Zhi Yan Liu zhiyanl@cn.ibm.com
