### PR TITLE
CCIManager should be not referred now since SL-api has changed it to VSManager

### DIFF
--- a/jumpgate/common/hooks/__init__.py
+++ b/jumpgate/common/hooks/__init__.py
@@ -9,7 +9,7 @@ LOG = logging.getLogger(__name__)
 class APIHooks(object):
     # singleton pattern: http://goo.gl/1MtF3B
 
-    class __APIHooks:
+    class __APIHooks(object):
 
         def __init__(self):
             self.reset()

--- a/jumpgate/common/hooks/__init__.py
+++ b/jumpgate/common/hooks/__init__.py
@@ -7,10 +7,8 @@ LOG = logging.getLogger(__name__)
 
 
 class APIHooks(object):
-    # singleton pattern: http://goo.gl/1MtF3B
-
-    class __APIHooks(object):
-
+    class __APIHooks:
+     # singleton pattern: http://goo.gl/1MtF3
         def __init__(self):
             self.reset()
 

--- a/jumpgate/common/hooks/__init__.py
+++ b/jumpgate/common/hooks/__init__.py
@@ -7,8 +7,9 @@ LOG = logging.getLogger(__name__)
 
 
 class APIHooks(object):
-    class __APIHooks:
-     # singleton pattern: http://goo.gl/1MtF3
+
+    class __APIHooks(object):
+        # singleton pattern: http://goo.gl/1MtF3
         def __init__(self):
             self.reset()
 

--- a/jumpgate/compute/drivers/sl/availability_zones.py
+++ b/jumpgate/compute/drivers/sl/availability_zones.py
@@ -7,7 +7,7 @@ from jumpgate.common import utils
 class AvailabilityZonesV2(object):
     def on_get(self, req, resp, tenant_id):
         client = req.env['sl_client']
-        cci = SoftLayer.CCIManager(client)
+        cci = SoftLayer.VSManager(client)
 
         all_options = cci.get_create_options()
 

--- a/jumpgate/compute/drivers/sl/server_ips.py
+++ b/jumpgate/compute/drivers/sl/server_ips.py
@@ -6,7 +6,7 @@ from jumpgate.common import error_handling
 class ServerIpsV2(object):
     def on_get(self, req, resp, tenant_id, server_id):
         client = req.env['sl_client']
-        cci = SoftLayer.CCIManager(client)
+        cci = SoftLayer.VSManager(client)
 
         instance = cci.get_instance(
             server_id, mask='id, primaryIpAddress, primaryBackendIpAddress')
@@ -41,7 +41,7 @@ class ServerIpsNetworkV2(object):
                                             message='Network does not exist')
 
         client = req.env['sl_client']
-        cci = SoftLayer.CCIManager(client)
+        cci = SoftLayer.VSManager(client)
         instance = cci.get_instance(server_id, mask='id, ' + network_mask)
 
         resp.body = {

--- a/jumpgate/compute/drivers/sl/servers.py
+++ b/jumpgate/compute/drivers/sl/servers.py
@@ -39,7 +39,7 @@ class ServerActionV2(object):
                                               message="Malformed request body")
 
         vg_client = req.env['sl_client']['Virtual_Guest']
-        cci = SoftLayer.CCIManager(req.env['sl_client'])
+        cci = SoftLayer.VSManager(req.env['sl_client'])
 
         try:
             instance_id = int(instance_id)
@@ -151,7 +151,7 @@ class ServersV2(object):
 
     def on_get(self, req, resp, tenant_id):
         client = req.env['sl_client']
-        cci = SoftLayer.CCIManager(client)
+        cci = SoftLayer.VSManager(client)
 
         params = get_list_params(req)
 
@@ -189,7 +189,7 @@ class ServersV2(object):
         payload['hourly'] = True
 
         networks = utils.lookup(body, 'server', 'networks')
-        cci = SoftLayer.CCIManager(client)
+        cci = SoftLayer.VSManager(client)
 
         try:
             self._handle_flavor(payload, body)
@@ -405,7 +405,7 @@ class ServersDetailV2(object):
 
     def on_get(self, req, resp, tenant_id=None):
         client = req.env['sl_client']
-        cci = SoftLayer.CCIManager(client)
+        cci = SoftLayer.VSManager(client)
 
         params = get_list_params(req)
 
@@ -428,7 +428,7 @@ class ServerV2(object):
 
     def on_get(self, req, resp, tenant_id, server_id):
         client = req.env['sl_client']
-        cci = SoftLayer.CCIManager(client)
+        cci = SoftLayer.VSManager(client)
 
         instance = cci.get_instance(server_id,
                                     mask=get_virtual_guest_mask())
@@ -439,7 +439,7 @@ class ServerV2(object):
 
     def on_delete(self, req, resp, tenant_id, server_id):
         client = req.env['sl_client']
-        cci = SoftLayer.CCIManager(client)
+        cci = SoftLayer.VSManager(client)
 
         try:
             cci.cancel_instance(server_id)
@@ -454,7 +454,7 @@ class ServerV2(object):
 
     def on_put(self, req, resp, tenant_id, server_id):
         client = req.env['sl_client']
-        cci = SoftLayer.CCIManager(client)
+        cci = SoftLayer.VSManager(client)
         body = json.loads(req.stream.read().decode())
 
         if 'name' in utils.lookup(body, 'server'):

--- a/jumpgate/compute/drivers/sl/usage.py
+++ b/jumpgate/compute/drivers/sl/usage.py
@@ -8,7 +8,7 @@ from jumpgate.compute.drivers.sl import servers
 class UsageV2(object):
     def on_get(self, req, resp, tenant_id, target_id):
         client = req.env['sl_client']
-        cci = SoftLayer.CCIManager(client)
+        cci = SoftLayer.VSManager(client)
         start_time = datetime.datetime.now() + datetime.timedelta(hours=-1)
         usage = {
             'server_usages': [],

--- a/tests/jumpgate-tests/compute/test_availability_zones.py
+++ b/tests/jumpgate-tests/compute/test_availability_zones.py
@@ -11,7 +11,7 @@ class TestAvailabilityZonesV2(unittest.TestCase):
         self.tenant_id = '1234'
         self.instance = AvailabilityZonesV2()
 
-    @patch('SoftLayer.CCIManager.get_create_options')
+    @patch('SoftLayer.VSManager.get_create_options')
     def test_on_get(self, mockOptions):
         mockOptions.return_value = {
             'datacenters':

--- a/tests/jumpgate-tests/compute/test_servers.py
+++ b/tests/jumpgate-tests/compute/test_servers.py
@@ -33,7 +33,7 @@ class TestServersServerActionV2(unittest.TestCase):
                                           flavors=flavors)
         instance.on_post(self.req, self.resp, tenant_id, instance_id)
 
-    @mock.patch('jumpgate.compute.drivers.sl.servers.SoftLayer.CCIManager')
+    @mock.patch('jumpgate.compute.drivers.sl.servers.SoftLayer.VSManager')
     def test_on_post_create(self, cciMock):
         body_str = '{"createImage": {"name": "foobar"}}'
         self.perform_server_action(body_str, TENANT_ID,
@@ -52,7 +52,7 @@ class TestServersServerActionV2(unittest.TestCase):
                                filter=filterMock, limit=1)
         self.assertEquals(self.resp.status, 202)
 
-    @mock.patch('jumpgate.compute.drivers.sl.servers.SoftLayer.CCIManager')
+    @mock.patch('jumpgate.compute.drivers.sl.servers.SoftLayer.VSManager')
     def test_on_post_create_fail(self, cciMock):
         client, env = get_client_env(body='{"createImage": \
         {"name": "foobar"}}')
@@ -104,7 +104,7 @@ class TestServersServerActionV2(unittest.TestCase):
         self.vg_clientMock.rebootDefault.assert_called_with(id=INSTANCE_ID)
 
     @mock.patch('jumpgate.compute.drivers.sl.servers.SoftLayer'
-                '.CCIManager.upgrade')
+                '.VSManager.upgrade')
     def test_on_post_resize(self, cciMock):
         body_str = '{"resize": {"flavorRef": "2"}}'
         self.perform_server_action(body_str, TENANT_ID, INSTANCE_ID,
@@ -155,7 +155,7 @@ class TestServersServerActionV2(unittest.TestCase):
 
 class TestServersServersDetailV2(unittest.TestCase):
 
-    @mock.patch('SoftLayer.CCIManager.list_instances')
+    @mock.patch('SoftLayer.VSManager.list_instances')
     def test_on_get(self, mockListInstance):
         client, env = get_client_env()
         href = u'http://localhost:5000/compute/v2/333582/servers/4846014'
@@ -251,7 +251,7 @@ class TestServerDetail(unittest.TestCase):
     in the response, but are specified in the Openstack API reference.
     Will add later when there is support.
     '''
-    @mock.patch('jumpgate.compute.drivers.sl.servers.SoftLayer.CCIManager'
+    @mock.patch('jumpgate.compute.drivers.sl.servers.SoftLayer.VSManager'
                 '.get_instance')
     def perform_server_detail(self, tenant_id, server_id, get_instance_mock):
         self.client, self.env = get_client_env()


### PR DESCRIPTION
taKE 2 
